### PR TITLE
feat: add LT+button modifier for PTZ camera targeting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -554,7 +554,7 @@ async fn run_app(
 
     // Initialize gamepad if enabled
     let _gamepad_mapper = if let Some(gamepad_config) = &config.gamepad {
-        input::gamepad::init(gamepad_config, router.clone()).await
+        input::gamepad::init(gamepad_config, router.clone(), api_state.update_tx.clone()).await
     } else {
         None
     };


### PR DESCRIPTION
## Summary
- Add LT (left trigger) as a modifier key for gamepad camera buttons
- When LT is held + A/B/X/Y pressed, sets PTZ camera target instead of switching camera view
- Broadcasts update to Stream Deck via WebSocket for UI sync
- Respects `enable_ptz` config per camera (ignores if PTZ disabled)

## Changes
- `src/input/gamepad/mapper.rs`: Track LT state, handle LT+button combo, broadcast updates
- `src/input/gamepad/mod.rs`: Pass broadcast sender to mapper
- `src/main.rs`: Pass `api_state.update_tx` to gamepad init

## Test plan
- [ ] Press A/B/X/Y without LT → camera switches normally (selectCamera)
- [ ] Hold LT + press A/B/X/Y → PTZ target changes, log shows "PTZ target set: gamepad1 -> CameraName"
- [ ] Stream Deck buttons update when PTZ target changes via gamepad
- [ ] Camera with `enable_ptz: false` → LT+button is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)