### PR TITLE
refactor: remove redundant clone_for_timer/reconnect aliases

### DIFF
--- a/src/drivers/obs/actions.rs
+++ b/src/drivers/obs/actions.rs
@@ -311,7 +311,7 @@ impl Driver for ObsDriver {
                 self.emit_status(crate::tray::ConnectionStatus::Disconnected);
 
                 // Start background reconnection
-                let driver_clone = self.clone_for_reconnect();
+                let driver_clone = self.clone_for_task();
                 tokio::spawn(async move {
                     driver_clone.schedule_reconnect().await;
                 });
@@ -330,7 +330,7 @@ impl Driver for ObsDriver {
             // Trigger reconnect if not already running
             if *self.reconnect_count.lock() == 0 {
                 debug!("Triggering background reconnection");
-                let driver_clone = self.clone_for_reconnect();
+                let driver_clone = self.clone_for_task();
                 tokio::spawn(async move {
                     driver_clone.schedule_reconnect().await;
                 });

--- a/src/drivers/obs/analog.rs
+++ b/src/drivers/obs/analog.rs
@@ -129,7 +129,7 @@ impl ObsDriver {
         let rates = Arc::clone(&self.analog_rates);
         let last_tick = Arc::clone(&self.last_analog_tick);
         let timer_active = Arc::clone(&self.analog_timer_active);
-        let driver_self = Arc::new(self.clone_for_timer());
+        let driver_self = Arc::new(self.clone_for_task());
 
         tokio::spawn(async move {
             let mut interval = interval(Duration::from_millis(16)); // ~60Hz

--- a/src/drivers/obs/connection.rs
+++ b/src/drivers/obs/connection.rs
@@ -45,7 +45,9 @@ impl ObsDriver {
     /// ```
     pub(super) async fn set_scene_for_mode(&self, scene_name: &str) -> Result<()> {
         let guard = self.get_connected_client().await?;
-        let client = guard.as_ref().unwrap(); // Safe: get_connected_client ensures Some
+        let client = guard
+            .as_ref()
+            .expect("invariant: get_connected_client ensures Some");
 
         let studio_mode = *self.studio_mode.read();
         if studio_mode {
@@ -110,7 +112,7 @@ impl ObsDriver {
         let camera_control_state = Arc::clone(&self.camera_control_state);
 
         // Clone for reconnection trigger
-        let driver_for_reconnect = self.clone_for_reconnect();
+        let driver_for_reconnect = self.clone_for_task();
         let status_callbacks = Arc::clone(&self.status_callbacks);
         let current_status = Arc::clone(&self.current_status);
 
@@ -290,7 +292,7 @@ impl ObsDriver {
                 }
 
                 // Trigger automatic reconnection
-                let driver_clone = driver_for_reconnect.clone_for_reconnect();
+                let driver_clone = driver_for_reconnect.clone_for_task();
                 tokio::spawn(async move {
                     driver_clone.schedule_reconnect().await;
                 });

--- a/src/drivers/obs/driver.rs
+++ b/src/drivers/obs/driver.rs
@@ -189,14 +189,4 @@ impl ObsDriver {
             camera_control_config: Arc::clone(&self.camera_control_config),
         }
     }
-
-    /// Alias for clone_for_task (backwards compatibility)
-    pub(super) fn clone_for_timer(&self) -> Self {
-        self.clone_for_task()
-    }
-
-    /// Alias for clone_for_task (backwards compatibility)
-    pub(super) fn clone_for_reconnect(&self) -> Self {
-        self.clone_for_task()
-    }
 }


### PR DESCRIPTION
## Summary

- Replace `clone_for_timer()` and `clone_for_reconnect()` with unified `clone_for_task()`
- Remove unnecessary backwards compatibility aliases (internal `pub(super)` API only)
- Use `expect()` instead of `unwrap()` for clearer invariant documentation

## Changes

Follow-up from PR #19 code review recommendations:

1. **Removed alias indirection**: The `clone_for_timer` and `clone_for_reconnect` methods were identical wrappers around `clone_for_task()`. Since they're internal (`pub(super)`), backwards compatibility is not a concern.

2. **Improved unwrap pattern**: Changed `.unwrap()` to `.expect("invariant: ...")` to document the safety invariant explicitly.

## Test plan

- [x] `cargo check` passes
- [x] All 117 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)