### PR TITLE
feat: winaudio driver + Voicemeeter-based page availability

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,6 +6535,7 @@ dependencies = [
  "tracing-subscriber",
  "tray-icon",
  "windows 0.56.0",
+ "windows-core 0.56.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,21 @@ egui = "0.29"
 eframe = { version = "0.29", default-features = false, features = ["default_fonts", "glow"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.56", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }
+windows = { version = "0.56", features = [
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Foundation",
+    "Win32_Media_Audio",
+    "Win32_Media_Audio_Endpoints",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_Variant",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Threading",
+    "implement",
+] }
+# Required at the crate root for the `windows::core::implement` macro,
+# which emits `::windows_core::...` paths.
+windows-core = "0.56"
 
 [build-dependencies]
 embed-resource = "2.4"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -307,8 +307,29 @@ pages_global:
       app: "voicemeeter"
       midi: {type: "passthrough"}
 
+# --- Profil son fallback ----------------------------------------------------
+# Lorsque Voicemeeter n'est pas lancé, la page tagguée
+# `auto_when_voicemeeter_absent: true` devient automatiquement active, et
+# les pages tagguées `requires_voicemeeter: true` sont skippées dans la
+# navigation prev/next. Quand VM revient, basculement auto vers la 1ère
+# page `requires_voicemeeter`.
+voicemeeter_detection:
+  enabled: true
+  poll_interval_ms: 5000
+  # process_names: omis = défauts (voicemeeter.exe, voicemeeter8x64.exe,
+  # voicemeeterpro.exe, voicemeeterbanana.exe, voicemeeterpotato.exe)
+
+# Apps audio Windows pinnées sur des faders fixes. Les autres faders se
+# remplissent en FIFO depuis les sessions audio actives au démarrage.
+winaudio:
+  pinned_apps:
+    - { fader: 1, process_name: "Discord.exe",  display_name: "Discord" }
+    - { fader: 2, process_name: "Spotify.exe",  display_name: "Spotify" }
+    - { fader: 3, process_name: "firefox.exe",  display_name: "Firefox" }
+
 pages:
   - name: "Voicemeeter+QLC"
+    requires_voicemeeter: true
     lcd:
       labels:
         - "Mic\nBaba"
@@ -371,7 +392,30 @@ pages:
       mute8:
         app: "voicemeeter"
         midi: {type: "passthrough"}
-  
+
+  - name: "Windows Audio"
+    auto_when_voicemeeter_absent: true
+    lcd:
+      labels: ["Discord", "Spotify", "Firefox", "App 4", "App 5", "App 6", "App 7", "MASTER"]
+      colors: [3, 2, 1, 7, 7, 7, 7, 5]
+    controls:
+      fader1: { app: "winaudio", action: "session_volume", params: ["pinned:1"] }
+      fader2: { app: "winaudio", action: "session_volume", params: ["pinned:2"] }
+      fader3: { app: "winaudio", action: "session_volume", params: ["pinned:3"] }
+      fader4: { app: "winaudio", action: "session_volume", params: ["discovered:0"] }
+      fader5: { app: "winaudio", action: "session_volume", params: ["discovered:1"] }
+      fader6: { app: "winaudio", action: "session_volume", params: ["discovered:2"] }
+      fader7: { app: "winaudio", action: "session_volume", params: ["discovered:3"] }
+      fader8: { app: "winaudio", action: "master_volume" }
+      mute1:  { app: "winaudio", action: "session_mute",   params: ["pinned:1"] }
+      mute2:  { app: "winaudio", action: "session_mute",   params: ["pinned:2"] }
+      mute3:  { app: "winaudio", action: "session_mute",   params: ["pinned:3"] }
+      mute4:  { app: "winaudio", action: "session_mute",   params: ["discovered:0"] }
+      mute5:  { app: "winaudio", action: "session_mute",   params: ["discovered:1"] }
+      mute6:  { app: "winaudio", action: "session_mute",   params: ["discovered:2"] }
+      mute7:  { app: "winaudio", action: "session_mute",   params: ["discovered:3"] }
+      mute8:  { app: "winaudio", action: "master_mute" }
+
   - name: "Lighting"
     lcd:
       labels:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -414,7 +414,7 @@ pages:
       mute5:  { app: "winaudio", action: "session_mute",   params: ["discovered:1"] }
       mute6:  { app: "winaudio", action: "session_mute",   params: ["discovered:2"] }
       mute7:  { app: "winaudio", action: "session_mute",   params: ["discovered:3"] }
-      mute8:  { app: "winaudio", action: "master_mute" }
+      flip:   { app: "winaudio", action: "master_mute" }
 
   - name: "Lighting"
     lcd:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -321,6 +321,8 @@ voicemeeter_detection:
 
 # Apps audio Windows pinnées sur des faders fixes. Les autres faders se
 # remplissent en FIFO depuis les sessions audio actives au démarrage.
+# Le binding fader↔action est défini dans la page (`controls:` ci-dessous);
+# le driver le résout dynamiquement via `control_mapping.csv`.
 winaudio:
   pinned_apps:
     - { fader: 1, process_name: "Discord.exe",  display_name: "Discord" }
@@ -396,9 +398,12 @@ pages:
   - name: "Windows Audio"
     auto_when_voicemeeter_absent: true
     lcd:
-      labels: ["Discord", "Spotify", "Firefox", "App 4", "App 5", "App 6", "App 7", "MASTER"]
-      colors: [3, 2, 1, 7, 7, 7, 7, 5]
+      labels: ["Discord", "Spotify", "Firefox", "App 4", "App 5", "App 6", "App 7", "App 8"]
+      colors: [3, 2, 1, 7, 7, 7, 7, 7]
     controls:
+      # Master volume / mute live exclusively on the dedicated master
+      # strip (fader_master) and the flip button — no channel-strip
+      # control is wired to them.
       fader1: { app: "winaudio", action: "session_volume", params: ["pinned:1"] }
       fader2: { app: "winaudio", action: "session_volume", params: ["pinned:2"] }
       fader3: { app: "winaudio", action: "session_volume", params: ["pinned:3"] }
@@ -406,7 +411,8 @@ pages:
       fader5: { app: "winaudio", action: "session_volume", params: ["discovered:1"] }
       fader6: { app: "winaudio", action: "session_volume", params: ["discovered:2"] }
       fader7: { app: "winaudio", action: "session_volume", params: ["discovered:3"] }
-      fader8: { app: "winaudio", action: "master_volume" }
+      fader8: { app: "winaudio", action: "session_volume", params: ["discovered:4"] }
+      fader_master: { app: "winaudio", action: "master_volume" }
       mute1:  { app: "winaudio", action: "session_mute",   params: ["pinned:1"] }
       mute2:  { app: "winaudio", action: "session_mute",   params: ["pinned:2"] }
       mute3:  { app: "winaudio", action: "session_mute",   params: ["pinned:3"] }
@@ -414,6 +420,7 @@ pages:
       mute5:  { app: "winaudio", action: "session_mute",   params: ["discovered:1"] }
       mute6:  { app: "winaudio", action: "session_mute",   params: ["discovered:2"] }
       mute7:  { app: "winaudio", action: "session_mute",   params: ["discovered:3"] }
+      mute8:  { app: "winaudio", action: "session_mute",   params: ["discovered:4"] }
       flip:   { app: "winaudio", action: "master_mute" }
 
   - name: "Lighting"

--- a/src/app.rs
+++ b/src/app.rs
@@ -481,17 +481,15 @@ fn spawn_voicemeeter_detector(
     let scanner: Arc<dyn ProcessScanner> =
         Arc::new(crate::router::voicemeeter_detector::NoopProcessScanner);
 
+    // Detector drops at end of scope; tokio detaches its `JoinHandle` on
+    // drop, and the watch sender lives inside the spawned task, so the
+    // watcher subscription below keeps publishing until app shutdown.
     let detector = VmDetector::spawn(
         scanner,
         cfg.process_names.clone(),
         Duration::from_millis(cfg.poll_interval_ms),
     );
-    let rx = detector.subscribe();
-    router.spawn_voicemeeter_watcher(rx);
-    // Keep the detector alive for the lifetime of the process by
-    // leaking it; the only resource it owns is a watch channel + a
-    // tokio task which exits on app shutdown anyway.
-    Box::leak(Box::new(detector));
+    router.spawn_voicemeeter_watcher(detector.subscribe());
     info!(
         "Voicemeeter detector running (poll {} ms, processes: {:?})",
         cfg.poll_interval_ms, cfg.process_names

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,7 +115,6 @@ pub async fn run_app(
 
     // Register MIDI bridge drivers and OBS driver
     driver_setup::register_midi_bridge_drivers(&config, &router, &feedback_tx, &tray_handler).await;
-    drop(feedback_tx); // Close when all drivers are shut down
 
     // Load control database for LED indicator mapping
     let control_db = driver_setup::load_control_database().await;
@@ -207,6 +206,16 @@ pub async fn run_app(
             &tray_handler,
         )
         .await;
+    }
+
+    // Register the Windows audio fallback driver (no-op on non-Windows).
+    driver_setup::register_winaudio_driver(&config, &router, &feedback_tx).await;
+
+    drop(feedback_tx); // Original sender dropped; clones live inside drivers.
+
+    // Voicemeeter presence detector → page availability + auto-switch.
+    if let Some(vm_cfg) = config.voicemeeter_detection.as_ref().filter(|c| c.enabled) {
+        spawn_voicemeeter_detector(&router, vm_cfg);
     }
 
     debug!("All drivers registered and initialized");
@@ -455,6 +464,38 @@ async fn shutdown_cleanup(router: &Arc<Router>, xtouch: &Arc<XTouchDriver>) -> R
     }
 
     Ok(())
+}
+
+/// Build the Voicemeeter detector and wire it into the router.
+fn spawn_voicemeeter_detector(
+    router: &Arc<Router>,
+    cfg: &crate::config::VoicemeeterDetectionConfig,
+) {
+    use crate::router::voicemeeter_detector::{ProcessScanner, VmDetector};
+    use std::time::Duration;
+
+    #[cfg(target_os = "windows")]
+    let scanner: Arc<dyn ProcessScanner> =
+        Arc::new(crate::router::voicemeeter_detector::Win32ProcessScanner);
+    #[cfg(not(target_os = "windows"))]
+    let scanner: Arc<dyn ProcessScanner> =
+        Arc::new(crate::router::voicemeeter_detector::NoopProcessScanner);
+
+    let detector = VmDetector::spawn(
+        scanner,
+        cfg.process_names.clone(),
+        Duration::from_millis(cfg.poll_interval_ms),
+    );
+    let rx = detector.subscribe();
+    router.spawn_voicemeeter_watcher(rx);
+    // Keep the detector alive for the lifetime of the process by
+    // leaking it; the only resource it owns is a watch channel + a
+    // tokio task which exits on app shutdown anyway.
+    Box::leak(Box::new(detector));
+    info!(
+        "Voicemeeter detector running (poll {} ms, processes: {:?})",
+        cfg.poll_interval_ms, cfg.process_names
+    );
 }
 
 /// Handle feedback from an application, forwarding to X-Touch when appropriate.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,7 +27,61 @@ pub struct AppConfig {
     pub tray: Option<TrayConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pages_global: Option<GlobalPageDefaults>,
+    /// Voicemeeter process detector — when configured, pages with
+    /// `requires_voicemeeter: true` are skipped while VM is absent and
+    /// the page tagged `auto_when_voicemeeter_absent: true` becomes
+    /// the active fallback.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub voicemeeter_detection: Option<VoicemeeterDetectionConfig>,
+    /// Windows audio (master + per-app session) configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub winaudio: Option<WinAudioConfig>,
     pub pages: Vec<PageConfig>,
+}
+
+/// Voicemeeter presence detection configuration.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct VoicemeeterDetectionConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_voicemeeter_process_names")]
+    pub process_names: Vec<String>,
+    #[serde(default = "default_voicemeeter_poll_interval_ms")]
+    pub poll_interval_ms: u64,
+}
+
+fn default_voicemeeter_process_names() -> Vec<String> {
+    vec![
+        "voicemeeter.exe".to_string(),
+        "voicemeeter8x64.exe".to_string(),
+        "voicemeeterpro.exe".to_string(),
+        "voicemeeterbanana.exe".to_string(),
+        "voicemeeterpotato.exe".to_string(),
+    ]
+}
+
+fn default_voicemeeter_poll_interval_ms() -> u64 {
+    5000
+}
+
+/// Windows audio driver configuration.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct WinAudioConfig {
+    /// Apps pinned to specific fader slots. Faders 1..=8.
+    #[serde(default)]
+    pub pinned_apps: Vec<PinnedApp>,
+}
+
+/// A pinned audio session: a process name fixed on a specific fader slot.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct PinnedApp {
+    /// Fader slot 1..=8.
+    pub fader: u8,
+    /// Process executable name (e.g. "Discord.exe"). Match is case-insensitive.
+    pub process_name: String,
+    /// Optional friendly label rendered on the LCD; falls back to process_name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
 }
 
 /// MIDI port configuration
@@ -260,6 +314,14 @@ pub struct PageConfig {
     pub passthrough: Option<PassthroughConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub passthroughs: Option<Vec<PassthroughConfig>>,
+    /// When true, this page is skipped in prev/next navigation while
+    /// Voicemeeter is not detected.
+    #[serde(default)]
+    pub requires_voicemeeter: bool,
+    /// When true, this page becomes the auto-active fallback while
+    /// Voicemeeter is not detected. Only one page may have this flag set.
+    #[serde(default)]
+    pub auto_when_voicemeeter_absent: bool,
 }
 
 /// LED indicator configuration
@@ -540,6 +602,47 @@ impl AppConfig {
             }
         }
 
+        // Voicemeeter fallback: at most one page may carry the
+        // `auto_when_voicemeeter_absent` flag.
+        let auto_pages: Vec<&str> = self
+            .pages
+            .iter()
+            .filter(|p| p.auto_when_voicemeeter_absent)
+            .map(|p| p.name.as_str())
+            .collect();
+        if auto_pages.len() > 1 {
+            anyhow::bail!(
+                "Multiple pages marked auto_when_voicemeeter_absent: {:?} (only one is allowed)",
+                auto_pages
+            );
+        }
+
+        // Validate winaudio pinned_apps slot range (1..=8) and uniqueness.
+        if let Some(winaudio) = &self.winaudio {
+            let mut seen = std::collections::HashSet::new();
+            for pin in &winaudio.pinned_apps {
+                if !(1..=8).contains(&pin.fader) {
+                    anyhow::bail!(
+                        "winaudio.pinned_apps: fader slot {} for '{}' must be in 1..=8",
+                        pin.fader,
+                        pin.process_name
+                    );
+                }
+                if !seen.insert(pin.fader) {
+                    anyhow::bail!(
+                        "winaudio.pinned_apps: fader slot {} is pinned more than once",
+                        pin.fader
+                    );
+                }
+                if pin.process_name.trim().is_empty() {
+                    anyhow::bail!(
+                        "winaudio.pinned_apps: process_name cannot be empty (fader {})",
+                        pin.fader
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -554,8 +657,11 @@ impl AppConfig {
             anyhow::bail!("Control '{}' app name cannot be empty", control_id);
         }
 
-        // Validate app name references a configured app (obs is special)
-        if mapping.app != "obs" && !midi_app_names.contains(&mapping.app) {
+        // Validate app name references a configured app
+        // (obs and winaudio are non-MIDI apps that don't need a port entry).
+        const NON_MIDI_APPS: &[&str] = &["obs", "winaudio"];
+        if !NON_MIDI_APPS.contains(&mapping.app.as_str()) && !midi_app_names.contains(&mapping.app)
+        {
             anyhow::bail!(
                 "Control '{}' references unknown app '{}'. Available apps: {:?}",
                 control_id,
@@ -710,5 +816,41 @@ mod tests {
             serde_json::to_string_pretty(&schema).expect("AppConfig schema must serialize to JSON");
         assert!(json.contains("AppConfig"));
         assert!(json.contains("MidiConfig"));
+    }
+
+    /// `config.example.yaml` must round-trip through the parser + validator.
+    /// Catches schema regressions before the bundled example silently breaks.
+    #[test]
+    fn example_config_parses_and_validates() {
+        let yaml = std::fs::read_to_string("config.example.yaml")
+            .expect("config.example.yaml must exist at repo root");
+        let parsed: AppConfig = serde_yaml::from_str(&yaml).expect("YAML parse failed");
+        parsed.validate().expect("config validation failed");
+
+        let vm = parsed
+            .voicemeeter_detection
+            .as_ref()
+            .expect("voicemeeter_detection block expected in example");
+        assert!(vm.enabled);
+        assert_eq!(vm.poll_interval_ms, 5000);
+
+        let win = parsed.winaudio.as_ref().expect("winaudio block expected");
+        assert_eq!(win.pinned_apps.len(), 3);
+
+        let auto_pages: Vec<&str> = parsed
+            .pages
+            .iter()
+            .filter(|p| p.auto_when_voicemeeter_absent)
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(auto_pages, ["Windows Audio"]);
+
+        let req_pages: Vec<&str> = parsed
+            .pages
+            .iter()
+            .filter(|p| p.requires_voicemeeter)
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(req_pages, ["Voicemeeter+QLC"]);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -70,6 +70,18 @@ pub struct WinAudioConfig {
     /// Apps pinned to specific fader slots. Faders 1..=8.
     #[serde(default)]
     pub pinned_apps: Vec<PinnedApp>,
+    /// Strip carrying `master_volume` / `master_mute` feedback. `1..=8`
+    /// targets one of the regular channel strips; `9` targets the
+    /// dedicated master strip on the X-Touch's right side. Must match
+    /// whatever YAML control (`fader1`..`fader8` / `fader_master`) the
+    /// page binds to `master_volume`. Defaults to `8` to match the
+    /// shipped Windows Audio layout (LCD slot 8 labelled MASTER).
+    #[serde(default = "default_master_fader")]
+    pub master_fader: u8,
+}
+
+fn default_master_fader() -> u8 {
+    8
 }
 
 /// A pinned audio session: a process name fixed on a specific fader slot.
@@ -617,8 +629,14 @@ impl AppConfig {
             );
         }
 
-        // Validate winaudio pinned_apps slot range (1..=8) and uniqueness.
+        // Validate winaudio master_fader slot range (1..=9) and pinned_apps.
         if let Some(winaudio) = &self.winaudio {
+            if !(1..=9).contains(&winaudio.master_fader) {
+                anyhow::bail!(
+                    "winaudio.master_fader must be in 1..=9 (got {}); 1..=8 = channel strips, 9 = dedicated master strip",
+                    winaudio.master_fader
+                );
+            }
             let mut seen = std::collections::HashSet::new();
             for pin in &winaudio.pinned_apps {
                 if !(1..=8).contains(&pin.fader) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -70,18 +70,30 @@ pub struct WinAudioConfig {
     /// Apps pinned to specific fader slots. Faders 1..=8.
     #[serde(default)]
     pub pinned_apps: Vec<PinnedApp>,
-    /// Strip carrying `master_volume` / `master_mute` feedback. `1..=8`
-    /// targets one of the regular channel strips; `9` targets the
-    /// dedicated master strip on the X-Touch's right side. Must match
-    /// whatever YAML control (`fader1`..`fader8` / `fader_master`) the
-    /// page binds to `master_volume`. Defaults to `8` to match the
-    /// shipped Windows Audio layout (LCD slot 8 labelled MASTER).
+    /// Strip carrying `master_volume` feedback. `1..=8` targets one of
+    /// the regular channel strips; `9` targets the dedicated master
+    /// strip on the X-Touch's right side. Must match whatever YAML
+    /// control (`fader1`..`fader8` / `fader_master`) the page binds to
+    /// `master_volume`. Defaults to `8` to match the shipped Windows
+    /// Audio layout (LCD slot 8 labelled MASTER).
     #[serde(default = "default_master_fader")]
     pub master_fader: u8,
+    /// MCU note number of the button bound to `master_mute` — drives
+    /// the corresponding LED. The X-Touch master strip has no dedicated
+    /// mute button, so this defaults to `50` (the `flip` button) which
+    /// is convenient and unambiguous; pages can map `master_mute` to
+    /// any note (e.g. `23` for `mute8`) and override this field to
+    /// match. See `docs/xtouch-matching.csv` for the note table.
+    #[serde(default = "default_master_mute_note")]
+    pub master_mute_note: u8,
 }
 
 fn default_master_fader() -> u8 {
     8
+}
+
+fn default_master_mute_note() -> u8 {
+    50
 }
 
 /// A pinned audio session: a process name fixed on a specific fader slot.
@@ -635,6 +647,12 @@ impl AppConfig {
                 anyhow::bail!(
                     "winaudio.master_fader must be in 1..=9 (got {}); 1..=8 = channel strips, 9 = dedicated master strip",
                     winaudio.master_fader
+                );
+            }
+            if winaudio.master_mute_note > 127 {
+                anyhow::bail!(
+                    "winaudio.master_mute_note must be a 7-bit MIDI note (0..=127), got {}",
+                    winaudio.master_mute_note
                 );
             }
             let mut seen = std::collections::HashSet::new();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -70,30 +70,6 @@ pub struct WinAudioConfig {
     /// Apps pinned to specific fader slots. Faders 1..=8.
     #[serde(default)]
     pub pinned_apps: Vec<PinnedApp>,
-    /// Strip carrying `master_volume` feedback. `1..=8` targets one of
-    /// the regular channel strips; `9` targets the dedicated master
-    /// strip on the X-Touch's right side. Must match whatever YAML
-    /// control (`fader1`..`fader8` / `fader_master`) the page binds to
-    /// `master_volume`. Defaults to `8` to match the shipped Windows
-    /// Audio layout (LCD slot 8 labelled MASTER).
-    #[serde(default = "default_master_fader")]
-    pub master_fader: u8,
-    /// MCU note number of the button bound to `master_mute` — drives
-    /// the corresponding LED. The X-Touch master strip has no dedicated
-    /// mute button, so this defaults to `50` (the `flip` button) which
-    /// is convenient and unambiguous; pages can map `master_mute` to
-    /// any note (e.g. `23` for `mute8`) and override this field to
-    /// match. See `docs/xtouch-matching.csv` for the note table.
-    #[serde(default = "default_master_mute_note")]
-    pub master_mute_note: u8,
-}
-
-fn default_master_fader() -> u8 {
-    8
-}
-
-fn default_master_mute_note() -> u8 {
-    50
 }
 
 /// A pinned audio session: a process name fixed on a specific fader slot.
@@ -641,20 +617,8 @@ impl AppConfig {
             );
         }
 
-        // Validate winaudio master_fader slot range (1..=9) and pinned_apps.
+        // Validate winaudio pinned_apps slot range and uniqueness.
         if let Some(winaudio) = &self.winaudio {
-            if !(1..=9).contains(&winaudio.master_fader) {
-                anyhow::bail!(
-                    "winaudio.master_fader must be in 1..=9 (got {}); 1..=8 = channel strips, 9 = dedicated master strip",
-                    winaudio.master_fader
-                );
-            }
-            if winaudio.master_mute_note > 127 {
-                anyhow::bail!(
-                    "winaudio.master_mute_note must be a 7-bit MIDI note (0..=127), got {}",
-                    winaudio.master_mute_note
-                );
-            }
             let mut seen = std::collections::HashSet::new();
             for pin in &winaudio.pinned_apps {
                 if !(1..=8).contains(&pin.fader) {

--- a/src/driver_setup.rs
+++ b/src/driver_setup.rs
@@ -172,6 +172,7 @@ pub async fn register_winaudio_driver(
         .unwrap_or_else(|| crate::config::WinAudioConfig {
             pinned_apps: Vec::new(),
             master_fader: 8,
+            master_mute_note: 50,
         });
 
     let driver = Arc::new(WinAudioDriver::new(winaudio_cfg));

--- a/src/driver_setup.rs
+++ b/src/driver_setup.rs
@@ -12,6 +12,7 @@ use crate::config::AppConfig;
 use crate::control_mapping::ControlMappingDB;
 use crate::drivers::midibridge::MidiBridgeDriver;
 use crate::drivers::obs::ObsDriver;
+use crate::drivers::winaudio::WinAudioDriver;
 use crate::drivers::Driver;
 use crate::router::Router;
 use crate::xtouch::XTouchDriver;
@@ -127,6 +128,62 @@ pub async fn register_obs_driver(
         Ok(_) => info!("Registered OBS driver"),
         Err(e) => warn!(
             "Failed to register OBS driver (will continue without it): {}",
+            e
+        ),
+    }
+}
+
+/// Register the Windows audio driver if `winaudio` is configured or any
+/// page references the `winaudio` app.
+///
+/// The driver itself is cross-platform (no-op on non-Windows); registration
+/// is unconditional once the config opts in, so YAML routing succeeds on
+/// any platform.
+///
+/// `feedback_tx` is cloned inside the driver and used by its COM thread
+/// consumer to inject volume-change feedback as if it came from a regular
+/// MIDI app — this routes through the existing anti-echo / fader-setpoint
+/// pipeline and keeps the X-Touch motorized fader in sync.
+pub async fn register_winaudio_driver(
+    config: &AppConfig,
+    router: &Arc<Router>,
+    feedback_tx: &mpsc::Sender<(String, Vec<u8>)>,
+) {
+    let referenced = config.pages.iter().any(|p| {
+        p.controls
+            .as_ref()
+            .map(|m| m.values().any(|c| c.app == "winaudio"))
+            .unwrap_or(false)
+    }) || config
+        .pages_global
+        .as_ref()
+        .and_then(|g| g.controls.as_ref())
+        .map(|m| m.values().any(|c| c.app == "winaudio"))
+        .unwrap_or(false);
+
+    if !referenced && config.winaudio.is_none() {
+        debug!("WinAudio driver not configured and unreferenced — skipping registration");
+        return;
+    }
+
+    let winaudio_cfg = config
+        .winaudio
+        .clone()
+        .unwrap_or_else(|| crate::config::WinAudioConfig {
+            pinned_apps: Vec::new(),
+        });
+
+    let driver = Arc::new(WinAudioDriver::new(winaudio_cfg));
+    driver.set_router(router.clone()).await;
+    driver.set_feedback_sender(feedback_tx.clone()).await;
+
+    match router
+        .register_driver(crate::drivers::winaudio::DRIVER_NAME.to_string(), driver)
+        .await
+    {
+        Ok(_) => info!("Registered WinAudio driver"),
+        Err(e) => warn!(
+            "Failed to register WinAudio driver (will continue without it): {}",
             e
         ),
     }

--- a/src/driver_setup.rs
+++ b/src/driver_setup.rs
@@ -171,6 +171,7 @@ pub async fn register_winaudio_driver(
         .clone()
         .unwrap_or_else(|| crate::config::WinAudioConfig {
             pinned_apps: Vec::new(),
+            master_fader: 8,
         });
 
     let driver = Arc::new(WinAudioDriver::new(winaudio_cfg));

--- a/src/driver_setup.rs
+++ b/src/driver_setup.rs
@@ -171,8 +171,6 @@ pub async fn register_winaudio_driver(
         .clone()
         .unwrap_or_else(|| crate::config::WinAudioConfig {
             pinned_apps: Vec::new(),
-            master_fader: 8,
-            master_mute_note: 50,
         });
 
     let driver = Arc::new(WinAudioDriver::new(winaudio_cfg));

--- a/src/drivers/console.rs
+++ b/src/drivers/console.rs
@@ -158,6 +158,8 @@ mod tests {
             paging: None,
             gamepad: None,
             pages_global: None,
+            voicemeeter_detection: None,
+            winaudio: None,
             pages: vec![],
             tray: None,
         };

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -120,8 +120,10 @@ pub trait Driver: Send + Sync {
 pub mod console;
 pub mod midibridge;
 pub mod obs;
+pub mod winaudio;
 
 // Re-export commonly used drivers
 pub use console::ConsoleDriver;
 pub use midibridge::MidiBridgeDriver;
 pub use obs::ObsDriver;
+pub use winaudio::WinAudioDriver;

--- a/src/drivers/winaudio/actions.rs
+++ b/src/drivers/winaudio/actions.rs
@@ -1,0 +1,96 @@
+//! Action parameter parsing for the WinAudio driver.
+//!
+//! Session-targeted actions accept a single string parameter of the form
+//! `"pinned:<N>"` or `"discovered:<N>"` where `N` is a 1-based slot for
+//! pinned apps and a 0-based index for discovery slots. The slot index is
+//! resolved at runtime by the driver's mapping layer to a concrete
+//! Windows audio session.
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionTarget {
+    /// Pinned slot, 1..=8 (matches the fader number declared in YAML).
+    Pinned(u8),
+    /// Discovery slot, 0-based, used to index into the FIFO list of
+    /// auto-discovered sessions that aren't pinned.
+    Discovered(u8),
+}
+
+pub fn parse_session_target(params: &[Value]) -> Result<SessionTarget> {
+    let raw = params
+        .first()
+        .ok_or_else(|| {
+            anyhow!("session action requires a target parameter (pinned:N or discovered:N)")
+        })?
+        .as_str()
+        .ok_or_else(|| anyhow!("session target must be a string (pinned:N or discovered:N)"))?;
+
+    let (kind, idx) = raw
+        .split_once(':')
+        .ok_or_else(|| anyhow!("session target '{}' missing ':' separator", raw))?;
+
+    let n: u8 = idx
+        .trim()
+        .parse()
+        .map_err(|_| anyhow!("session target '{}': index '{}' is not a u8", raw, idx))?;
+
+    match kind.trim() {
+        "pinned" => {
+            if !(1..=8).contains(&n) {
+                return Err(anyhow!("pinned slot {} must be in 1..=8", n));
+            }
+            Ok(SessionTarget::Pinned(n))
+        },
+        "discovered" => {
+            if n >= 8 {
+                return Err(anyhow!("discovered slot {} must be < 8", n));
+            }
+            Ok(SessionTarget::Discovered(n))
+        },
+        other => Err(anyhow!(
+            "unknown session target kind '{}': expected 'pinned' or 'discovered'",
+            other
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_pinned() {
+        let p = parse_session_target(&[json!("pinned:3")]).unwrap();
+        assert_eq!(p, SessionTarget::Pinned(3));
+    }
+
+    #[test]
+    fn parses_discovered() {
+        let p = parse_session_target(&[json!("discovered:2")]).unwrap();
+        assert_eq!(p, SessionTarget::Discovered(2));
+    }
+
+    #[test]
+    fn rejects_missing_separator() {
+        assert!(parse_session_target(&[json!("pinned3")]).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_kind() {
+        assert!(parse_session_target(&[json!("foo:1")]).is_err());
+    }
+
+    #[test]
+    fn rejects_pinned_out_of_range() {
+        assert!(parse_session_target(&[json!("pinned:9")]).is_err());
+        assert!(parse_session_target(&[json!("pinned:0")]).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_param() {
+        assert!(parse_session_target(&[]).is_err());
+    }
+}

--- a/src/drivers/winaudio/callback.rs
+++ b/src/drivers/winaudio/callback.rs
@@ -2,9 +2,9 @@
 //!
 //! Implements `IAudioEndpointVolumeCallback` so external volume changes
 //! (Win+Vol+/-, hardware buttons, the Windows mixer) flow back into the
-//! gateway and drive the motorized fader / mute LED. The callback runs
-//! on the COM (STA) thread; the only work it does is post a lightweight
-//! `AudioEvent` onto the unbounded mpsc channel.
+//! gateway and drive the motorized fader / mute LED. Runs on the OS
+//! audio thread, so it must be non-blocking — `try_send` and drop on
+//! full.
 
 #![cfg(target_os = "windows")]
 
@@ -19,11 +19,11 @@ use super::com_thread::AudioEvent;
 
 #[implement(windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolumeCallback)]
 pub struct EndpointVolumeCallback {
-    tx: mpsc::UnboundedSender<AudioEvent>,
+    tx: mpsc::Sender<AudioEvent>,
 }
 
 impl EndpointVolumeCallback {
-    pub fn new(tx: mpsc::UnboundedSender<AudioEvent>) -> Self {
+    pub fn new(tx: mpsc::Sender<AudioEvent>) -> Self {
         Self { tx }
     }
 }
@@ -38,7 +38,7 @@ impl IAudioEndpointVolumeCallback_Impl for EndpointVolumeCallback {
         trace!("OnNotify: scalar={:.3} mute={}", scalar, mute);
         let _ = self
             .tx
-            .send(AudioEvent::MasterVolumeChanged { scalar, mute });
+            .try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
         Ok(())
     }
 }

--- a/src/drivers/winaudio/callback.rs
+++ b/src/drivers/winaudio/callback.rs
@@ -1,0 +1,44 @@
+//! COM callback wrappers for Windows audio events.
+//!
+//! Implements `IAudioEndpointVolumeCallback` so external volume changes
+//! (Win+Vol+/-, hardware buttons, the Windows mixer) flow back into the
+//! gateway and drive the motorized fader / mute LED. The callback runs
+//! on the COM (STA) thread; the only work it does is post a lightweight
+//! `AudioEvent` onto the unbounded mpsc channel.
+
+#![cfg(target_os = "windows")]
+
+use tokio::sync::mpsc;
+use tracing::trace;
+
+use windows::core::implement;
+use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolumeCallback_Impl;
+use windows::Win32::Media::Audio::AUDIO_VOLUME_NOTIFICATION_DATA;
+
+use super::com_thread::AudioEvent;
+
+#[implement(windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolumeCallback)]
+pub struct EndpointVolumeCallback {
+    tx: mpsc::UnboundedSender<AudioEvent>,
+}
+
+impl EndpointVolumeCallback {
+    pub fn new(tx: mpsc::UnboundedSender<AudioEvent>) -> Self {
+        Self { tx }
+    }
+}
+
+impl IAudioEndpointVolumeCallback_Impl for EndpointVolumeCallback {
+    fn OnNotify(&self, pnotify: *mut AUDIO_VOLUME_NOTIFICATION_DATA) -> windows::core::Result<()> {
+        // SAFETY: The pointer is provided by the audio engine and is
+        // guaranteed valid for the duration of this call.
+        let data = unsafe { &*pnotify };
+        let scalar = data.fMasterVolume.clamp(0.0, 1.0);
+        let mute = data.bMuted.as_bool();
+        trace!("OnNotify: scalar={:.3} mute={}", scalar, mute);
+        let _ = self
+            .tx
+            .send(AudioEvent::MasterVolumeChanged { scalar, mute });
+        Ok(())
+    }
+}

--- a/src/drivers/winaudio/com_thread.rs
+++ b/src/drivers/winaudio/com_thread.rs
@@ -293,14 +293,33 @@ fn run_com_loop(cmd_rx: &mut mpsc::Receiver<AudioCmd>, event_tx: mpsc::Sender<Au
                 }
             },
             AudioCmd::ToggleSessionMute { process_name_lc } => {
+                // Sessions have no callback equivalent to
+                // `IAudioEndpointVolumeCallback`, so the mute LED would
+                // never refresh unless we push a snapshot here ourselves.
                 if let Some(mgr) = session_mgr.as_ref() {
                     match mgr.enumerate() {
                         Ok(sessions) => {
                             if let Some(s) =
                                 super::mapping::find_session(&sessions, &process_name_lc)
                             {
-                                if let Err(e) = toggle_session_mute(s) {
-                                    warn!("ToggleSessionMute({}) failed: {}", process_name_lc, e);
+                                match toggle_session_mute(s) {
+                                    Ok(()) => {
+                                        let scalar =
+                                            unsafe { s.volume.GetMasterVolume().unwrap_or(0.0) };
+                                        let mute = unsafe {
+                                            s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false)
+                                        };
+                                        let _ =
+                                            event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
+                                                process_name_lc: process_name_lc.clone(),
+                                                scalar,
+                                                mute,
+                                            });
+                                    },
+                                    Err(e) => warn!(
+                                        "ToggleSessionMute({}) failed: {}",
+                                        process_name_lc, e
+                                    ),
                                 }
                             }
                         },

--- a/src/drivers/winaudio/com_thread.rs
+++ b/src/drivers/winaudio/com_thread.rs
@@ -66,16 +66,27 @@ pub enum AudioEvent {
     },
 }
 
+/// Bounded capacity for the command queue. Faders generate ~30 PB/s; 64
+/// is plenty of headroom while keeping memory bounded if the COM thread
+/// stalls. Senders use `try_send` and drop on full — losing a stale
+/// fader sample is preferred over unbounded growth.
+const CMD_QUEUE: usize = 64;
+/// Bounded capacity for the event queue. The OS audio engine fires
+/// `OnNotify` per channel-change; 256 covers a burst from a sweeping
+/// system mixer without growing the queue indefinitely if the consumer
+/// stalls (e.g. router lock contention).
+const EVENT_QUEUE: usize = 256;
+
 pub struct ComThreadHandle {
-    cmd_tx: mpsc::UnboundedSender<AudioCmd>,
-    event_rx: Arc<Mutex<Option<mpsc::UnboundedReceiver<AudioEvent>>>>,
+    cmd_tx: mpsc::Sender<AudioCmd>,
+    event_rx: Arc<Mutex<Option<mpsc::Receiver<AudioEvent>>>>,
     join: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl ComThreadHandle {
     pub fn spawn() -> anyhow::Result<Self> {
-        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<AudioCmd>();
-        let (event_tx, event_rx) = mpsc::unbounded_channel::<AudioEvent>();
+        let (cmd_tx, mut cmd_rx) = mpsc::channel::<AudioCmd>(CMD_QUEUE);
+        let (event_tx, event_rx) = mpsc::channel::<AudioEvent>(EVENT_QUEUE);
 
         let join = std::thread::Builder::new()
             .name("xtouch-gw-winaudio".into())
@@ -89,23 +100,23 @@ impl ComThreadHandle {
     }
 
     pub fn set_master_scalar(&self, scalar: f32) {
-        let _ = self.cmd_tx.send(AudioCmd::SetMasterScalar(scalar));
+        let _ = self.cmd_tx.try_send(AudioCmd::SetMasterScalar(scalar));
     }
 
     pub fn toggle_master_mute(&self) {
-        let _ = self.cmd_tx.send(AudioCmd::ToggleMasterMute);
+        let _ = self.cmd_tx.try_send(AudioCmd::ToggleMasterMute);
     }
 
     pub fn refresh_master(&self) {
-        let _ = self.cmd_tx.send(AudioCmd::RefreshMaster);
+        let _ = self.cmd_tx.try_send(AudioCmd::RefreshMaster);
     }
 
     pub fn refresh_sessions(&self) {
-        let _ = self.cmd_tx.send(AudioCmd::RefreshSessions);
+        let _ = self.cmd_tx.try_send(AudioCmd::RefreshSessions);
     }
 
     pub fn set_session_scalar(&self, process_name_lc: String, scalar: f32) {
-        let _ = self.cmd_tx.send(AudioCmd::SetSessionScalar {
+        let _ = self.cmd_tx.try_send(AudioCmd::SetSessionScalar {
             process_name_lc,
             scalar,
         });
@@ -114,7 +125,7 @@ impl ComThreadHandle {
     pub fn toggle_session_mute(&self, process_name_lc: String) {
         let _ = self
             .cmd_tx
-            .send(AudioCmd::ToggleSessionMute { process_name_lc });
+            .try_send(AudioCmd::ToggleSessionMute { process_name_lc });
     }
 
     pub async fn enumerate_sessions(&self) -> Vec<String> {
@@ -122,6 +133,7 @@ impl ComThreadHandle {
         if self
             .cmd_tx
             .send(AudioCmd::EnumerateSessions { reply })
+            .await
             .is_err()
         {
             return Vec::new();
@@ -130,12 +142,12 @@ impl ComThreadHandle {
     }
 
     /// Take the event receiver (one-shot — only one consumer is supported).
-    pub async fn take_event_rx(&self) -> Option<mpsc::UnboundedReceiver<AudioEvent>> {
+    pub async fn take_event_rx(&self) -> Option<mpsc::Receiver<AudioEvent>> {
         self.event_rx.lock().await.take()
     }
 
     pub async fn shutdown(self) {
-        let _ = self.cmd_tx.send(AudioCmd::Shutdown);
+        let _ = self.cmd_tx.send(AudioCmd::Shutdown).await;
         if let Some(join) = self.join.lock().await.take() {
             let _ = tokio::task::spawn_blocking(move || {
                 if let Err(e) = join.join() {
@@ -147,10 +159,7 @@ impl ComThreadHandle {
     }
 }
 
-fn run_com_loop(
-    cmd_rx: &mut mpsc::UnboundedReceiver<AudioCmd>,
-    event_tx: mpsc::UnboundedSender<AudioEvent>,
-) {
+fn run_com_loop(cmd_rx: &mut mpsc::Receiver<AudioCmd>, event_tx: mpsc::Sender<AudioEvent>) {
     // SAFETY: STA is required for IAudioSessionEvents callbacks; this thread
     // owns its apartment and never lets COM objects cross thread boundaries.
     let init = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
@@ -196,7 +205,7 @@ fn run_com_loop(
     // Push initial state so the X-Touch is in sync immediately.
     if let Some(ep) = endpoint.as_ref() {
         if let (Ok(scalar), Ok(mute)) = (ep.get_volume_scalar(), ep.get_mute()) {
-            let _ = event_tx.send(AudioEvent::MasterVolumeChanged { scalar, mute });
+            let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
         }
     }
 
@@ -210,7 +219,7 @@ fn run_com_loop(
                         warn!("set_volume_scalar({}) failed: {}", scalar, e);
                     } else {
                         let mute = ep.get_mute().unwrap_or(false);
-                        let _ = event_tx.send(AudioEvent::MasterVolumeChanged { scalar, mute });
+                        let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
                     }
                 }
             },
@@ -229,7 +238,7 @@ fn run_com_loop(
             AudioCmd::RefreshMaster => {
                 if let Some(ep) = endpoint.as_ref() {
                     if let (Ok(scalar), Ok(mute)) = (ep.get_volume_scalar(), ep.get_mute()) {
-                        let _ = event_tx.send(AudioEvent::MasterVolumeChanged { scalar, mute });
+                        let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
                     }
                 }
             },
@@ -245,7 +254,7 @@ fn run_com_loop(
                                 let mute = unsafe {
                                     s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false)
                                 };
-                                let _ = event_tx.send(AudioEvent::SessionVolumeSnapshot {
+                                let _ = event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
                                     process_name_lc: s.process_name,
                                     scalar,
                                     mute,

--- a/src/drivers/winaudio/com_thread.rs
+++ b/src/drivers/winaudio/com_thread.rs
@@ -230,8 +230,8 @@ fn run_com_loop(cmd_rx: &mut mpsc::Receiver<AudioCmd>, event_tx: mpsc::Sender<Au
                         warn!("set_mute failed: {}", e);
                     } else {
                         let scalar = ep.get_volume_scalar().unwrap_or(0.0);
-                        let _ =
-                            event_tx.send(AudioEvent::MasterVolumeChanged { scalar, mute: !cur });
+                        let _ = event_tx
+                            .try_send(AudioEvent::MasterVolumeChanged { scalar, mute: !cur });
                     }
                 }
             },

--- a/src/drivers/winaudio/com_thread.rs
+++ b/src/drivers/winaudio/com_thread.rs
@@ -6,6 +6,7 @@
 
 #![cfg(target_os = "windows")]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
@@ -14,11 +15,15 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, info, trace, warn};
 
 use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolumeCallback;
+use windows::Win32::Media::Audio::{
+    IAudioSessionControl2, IAudioSessionEvents, IAudioSessionNotification,
+};
 use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
 
 use super::callback::EndpointVolumeCallback;
 use super::master::MasterEndpoint;
 use super::session::{set_session_volume, toggle_session_mute, SessionManager};
+use super::session_events::{NewSessionCallback, SessionEventsCallback};
 
 #[derive(Debug)]
 pub enum AudioCmd {
@@ -88,9 +93,13 @@ impl ComThreadHandle {
         let (cmd_tx, mut cmd_rx) = mpsc::channel::<AudioCmd>(CMD_QUEUE);
         let (event_tx, event_rx) = mpsc::channel::<AudioEvent>(EVENT_QUEUE);
 
+        // Cloned into the COM thread so the new-session COM callback
+        // (registered on `IAudioSessionManager2`) can request a refresh
+        // when an app starts producing audio after init.
+        let cmd_tx_for_loop = cmd_tx.clone();
         let join = std::thread::Builder::new()
             .name("xtouch-gw-winaudio".into())
-            .spawn(move || run_com_loop(&mut cmd_rx, event_tx))?;
+            .spawn(move || run_com_loop(&mut cmd_rx, event_tx, cmd_tx_for_loop))?;
 
         Ok(Self {
             cmd_tx,
@@ -159,7 +168,19 @@ impl ComThreadHandle {
     }
 }
 
-fn run_com_loop(cmd_rx: &mut mpsc::Receiver<AudioCmd>, event_tx: mpsc::Sender<AudioEvent>) {
+/// Per-PID registration: we keep the `IAudioSessionControl2` so we can
+/// unregister at shutdown, and the `IAudioSessionEvents` interface so the
+/// audio engine has a live reference to call back into.
+struct SessionReg {
+    control: IAudioSessionControl2,
+    events: IAudioSessionEvents,
+}
+
+fn run_com_loop(
+    cmd_rx: &mut mpsc::Receiver<AudioCmd>,
+    event_tx: mpsc::Sender<AudioEvent>,
+    cmd_tx: mpsc::Sender<AudioCmd>,
+) {
     // SAFETY: STA is required for IAudioSessionEvents callbacks; this thread
     // owns its apartment and never lets COM objects cross thread boundaries.
     let init = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
@@ -184,9 +205,9 @@ fn run_com_loop(cmd_rx: &mut mpsc::Receiver<AudioCmd>, event_tx: mpsc::Sender<Au
         },
     };
 
-    // Register the volume-change callback. Must keep the COM reference
-    // alive in scope so the audio engine can call back into it; we
-    // unregister before drop.
+    // Register the master volume-change callback. Must keep the COM
+    // reference alive in scope so the audio engine can call back into
+    // it; we unregister before drop.
     let registered = endpoint.as_ref().and_then(|ep| {
         let cb_impl = EndpointVolumeCallback::new(event_tx.clone());
         let cb: IAudioEndpointVolumeCallback = cb_impl.into();
@@ -202,11 +223,39 @@ fn run_com_loop(cmd_rx: &mut mpsc::Receiver<AudioCmd>, event_tx: mpsc::Sender<Au
         }
     });
 
-    // Push initial state so the X-Touch is in sync immediately.
+    // Register the new-session notification so we hear about sessions
+    // that appear after init (e.g. an app starts producing audio).
+    let new_session_reg = session_mgr.as_ref().and_then(|mgr| {
+        let cb_impl = NewSessionCallback::new(cmd_tx.clone());
+        let cb: IAudioSessionNotification = cb_impl.into();
+        match unsafe { mgr.manager.RegisterSessionNotification(&cb) } {
+            Ok(()) => {
+                debug!("RegisterSessionNotification succeeded");
+                Some(cb)
+            },
+            Err(e) => {
+                warn!("RegisterSessionNotification failed: {:?}", e);
+                None
+            },
+        }
+    });
+
+    // Track per-session registrations by PID so we register events
+    // exactly once per session and can unregister on shutdown.
+    let mut session_regs: HashMap<u32, SessionReg> = HashMap::new();
+
+    // Push initial master state so the X-Touch is in sync immediately.
     if let Some(ep) = endpoint.as_ref() {
         if let (Ok(scalar), Ok(mute)) = (ep.get_volume_scalar(), ep.get_mute()) {
             let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
         }
+    }
+
+    // Initial session pass: register events on every active session and
+    // push their current state. This handles apps that already had
+    // audio sessions open when the gateway started.
+    if let Some(mgr) = session_mgr.as_ref() {
+        register_session_events_for_all(mgr, &event_tx, &mut session_regs);
     }
 
     info!("WinAudio COM loop running");
@@ -244,25 +293,7 @@ fn run_com_loop(cmd_rx: &mut mpsc::Receiver<AudioCmd>, event_tx: mpsc::Sender<Au
             },
             AudioCmd::RefreshSessions => {
                 if let Some(mgr) = session_mgr.as_ref() {
-                    match mgr.enumerate() {
-                        Ok(sessions) => {
-                            for s in sessions {
-                                if s.process_name.is_empty() {
-                                    continue;
-                                }
-                                let scalar = unsafe { s.volume.GetMasterVolume().unwrap_or(0.0) };
-                                let mute = unsafe {
-                                    s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false)
-                                };
-                                let _ = event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
-                                    process_name_lc: s.process_name,
-                                    scalar,
-                                    mute,
-                                });
-                            }
-                        },
-                        Err(e) => warn!("RefreshSessions enumerate failed: {}", e),
-                    }
+                    register_session_events_for_all(mgr, &event_tx, &mut session_regs);
                 }
             },
             AudioCmd::SetSessionScalar {
@@ -348,14 +379,94 @@ fn run_com_loop(cmd_rx: &mut mpsc::Receiver<AudioCmd>, event_tx: mpsc::Sender<Au
         }
     }
 
-    // Unregister the callback before dropping the endpoint.
+    // Unregister per-session events.
+    for (pid, reg) in session_regs.drain() {
+        if let Err(e) = unsafe { reg.control.UnregisterAudioSessionNotification(&reg.events) } {
+            warn!(
+                "UnregisterAudioSessionNotification(pid={}) failed: {:?}",
+                pid, e
+            );
+        }
+    }
+
+    // Unregister the new-session notification.
+    if let (Some(mgr), Some(cb)) = (session_mgr.as_ref(), new_session_reg.as_ref()) {
+        if let Err(e) = unsafe { mgr.manager.UnregisterSessionNotification(cb) } {
+            warn!("UnregisterSessionNotification failed: {:?}", e);
+        }
+    }
+
+    // Unregister the master volume-change callback.
     if let (Some(ep), Some(cb)) = (endpoint.as_ref(), registered.as_ref()) {
         if let Err(e) = unsafe { ep.iface().UnregisterControlChangeNotify(cb) } {
             warn!("UnregisterControlChangeNotify failed: {:?}", e);
         }
     }
     drop(registered);
+    drop(new_session_reg);
     drop(endpoint);
     drop(session_mgr);
     unsafe { CoUninitialize() };
+}
+
+/// Enumerate all sessions, register an `IAudioSessionEvents` callback on
+/// each new one, and push a `SessionVolumeSnapshot` so the consumer sees
+/// every session's current state immediately. Re-running this is safe:
+/// already-registered sessions are skipped (looked up by PID).
+fn register_session_events_for_all(
+    mgr: &SessionManager,
+    event_tx: &mpsc::Sender<AudioEvent>,
+    session_regs: &mut HashMap<u32, SessionReg>,
+) {
+    let sessions = match mgr.enumerate() {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("session enumerate failed: {}", e);
+            return;
+        },
+    };
+
+    for s in sessions {
+        if s.process_name.is_empty() {
+            continue;
+        }
+
+        // Always push the current state — the consumer is idempotent and
+        // this is what catches sessions whose volume changed while we
+        // weren't subscribed (or before our callback was registered).
+        let scalar = unsafe { s.volume.GetMasterVolume().unwrap_or(0.0) };
+        let mute = unsafe { s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false) };
+        let _ = event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
+            process_name_lc: s.process_name.clone(),
+            scalar,
+            mute,
+        });
+
+        // Skip if we already have an events callback registered for this PID.
+        if session_regs.contains_key(&s.pid) {
+            continue;
+        }
+
+        let cb_impl = SessionEventsCallback::new(event_tx.clone(), s.process_name.clone());
+        let events: IAudioSessionEvents = cb_impl.into();
+        match unsafe { s.control.RegisterAudioSessionNotification(&events) } {
+            Ok(()) => {
+                debug!(
+                    "RegisterAudioSessionNotification(pid={}, {}) succeeded",
+                    s.pid, s.process_name
+                );
+                session_regs.insert(
+                    s.pid,
+                    SessionReg {
+                        control: s.control,
+                        events,
+                    },
+                );
+            },
+            Err(e) => warn!(
+                "RegisterAudioSessionNotification(pid={}, {}) failed: {:?}",
+                s.pid, s.process_name, e
+            ),
+        }
+    }
 }

--- a/src/drivers/winaudio/com_thread.rs
+++ b/src/drivers/winaudio/com_thread.rs
@@ -1,0 +1,333 @@
+//! Dedicated COM (STA) thread for Win32 audio operations.
+//!
+//! Public API is the [`ComThreadHandle`]: spawn the thread, send commands
+//! over an `mpsc` channel, and shut it down on driver teardown. All COM
+//! interface usage is confined to this thread.
+
+#![cfg(target_os = "windows")]
+
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, trace, warn};
+
+use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolumeCallback;
+use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
+
+use super::callback::EndpointVolumeCallback;
+use super::master::MasterEndpoint;
+use super::session::{set_session_volume, toggle_session_mute, SessionManager};
+
+#[derive(Debug)]
+pub enum AudioCmd {
+    SetMasterScalar(f32),
+    ToggleMasterMute,
+    /// Read the current master endpoint state and push it as an
+    /// `AudioEvent::MasterVolumeChanged` event. Used to re-sync the
+    /// X-Touch fader after a page change to "Windows Audio" (the
+    /// `IAudioEndpointVolumeCallback` only fires on volume *changes*,
+    /// not on demand).
+    RefreshMaster,
+    /// Re-enumerate active sessions and emit one
+    /// `AudioEvent::SessionVolumeSnapshot` per session.
+    RefreshSessions,
+    /// Set volume (0.0..=1.0) for the first session whose process name
+    /// matches `process_name_lc` (lowercase). Silently ignored if no
+    /// matching session exists.
+    SetSessionScalar {
+        process_name_lc: String,
+        scalar: f32,
+    },
+    ToggleSessionMute {
+        process_name_lc: String,
+    },
+    /// Re-enumerate active sessions and reply with the lowercase exe
+    /// names via `reply` (oneshot).
+    EnumerateSessions {
+        reply: tokio::sync::oneshot::Sender<Vec<String>>,
+    },
+    Shutdown,
+}
+
+#[derive(Debug, Clone)]
+pub enum AudioEvent {
+    MasterVolumeChanged {
+        scalar: f32,
+        mute: bool,
+    },
+    /// Emitted on demand (after `RefreshSessions`) for each active session.
+    /// `process_name_lc` is the lowercase exe name (e.g. "discord.exe").
+    SessionVolumeSnapshot {
+        process_name_lc: String,
+        scalar: f32,
+        mute: bool,
+    },
+}
+
+pub struct ComThreadHandle {
+    cmd_tx: mpsc::UnboundedSender<AudioCmd>,
+    event_rx: Arc<Mutex<Option<mpsc::UnboundedReceiver<AudioEvent>>>>,
+    join: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl ComThreadHandle {
+    pub fn spawn() -> anyhow::Result<Self> {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<AudioCmd>();
+        let (event_tx, event_rx) = mpsc::unbounded_channel::<AudioEvent>();
+
+        let join = std::thread::Builder::new()
+            .name("xtouch-gw-winaudio".into())
+            .spawn(move || run_com_loop(&mut cmd_rx, event_tx))?;
+
+        Ok(Self {
+            cmd_tx,
+            event_rx: Arc::new(Mutex::new(Some(event_rx))),
+            join: Mutex::new(Some(join)),
+        })
+    }
+
+    pub fn set_master_scalar(&self, scalar: f32) {
+        let _ = self.cmd_tx.send(AudioCmd::SetMasterScalar(scalar));
+    }
+
+    pub fn toggle_master_mute(&self) {
+        let _ = self.cmd_tx.send(AudioCmd::ToggleMasterMute);
+    }
+
+    pub fn refresh_master(&self) {
+        let _ = self.cmd_tx.send(AudioCmd::RefreshMaster);
+    }
+
+    pub fn refresh_sessions(&self) {
+        let _ = self.cmd_tx.send(AudioCmd::RefreshSessions);
+    }
+
+    pub fn set_session_scalar(&self, process_name_lc: String, scalar: f32) {
+        let _ = self.cmd_tx.send(AudioCmd::SetSessionScalar {
+            process_name_lc,
+            scalar,
+        });
+    }
+
+    pub fn toggle_session_mute(&self, process_name_lc: String) {
+        let _ = self
+            .cmd_tx
+            .send(AudioCmd::ToggleSessionMute { process_name_lc });
+    }
+
+    pub async fn enumerate_sessions(&self) -> Vec<String> {
+        let (reply, rx) = tokio::sync::oneshot::channel();
+        if self
+            .cmd_tx
+            .send(AudioCmd::EnumerateSessions { reply })
+            .is_err()
+        {
+            return Vec::new();
+        }
+        rx.await.unwrap_or_default()
+    }
+
+    /// Take the event receiver (one-shot — only one consumer is supported).
+    pub async fn take_event_rx(&self) -> Option<mpsc::UnboundedReceiver<AudioEvent>> {
+        self.event_rx.lock().await.take()
+    }
+
+    pub async fn shutdown(self) {
+        let _ = self.cmd_tx.send(AudioCmd::Shutdown);
+        if let Some(join) = self.join.lock().await.take() {
+            let _ = tokio::task::spawn_blocking(move || {
+                if let Err(e) = join.join() {
+                    error!("WinAudio COM thread join failed: {:?}", e);
+                }
+            })
+            .await;
+        }
+    }
+}
+
+fn run_com_loop(
+    cmd_rx: &mut mpsc::UnboundedReceiver<AudioCmd>,
+    event_tx: mpsc::UnboundedSender<AudioEvent>,
+) {
+    // SAFETY: STA is required for IAudioSessionEvents callbacks; this thread
+    // owns its apartment and never lets COM objects cross thread boundaries.
+    let init = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    if init.is_err() {
+        error!("CoInitializeEx failed: {:?}", init);
+        return;
+    }
+
+    let endpoint = match MasterEndpoint::open() {
+        Ok(ep) => Some(ep),
+        Err(e) => {
+            warn!("WinAudio default render endpoint unavailable: {}", e);
+            None
+        },
+    };
+
+    let session_mgr = match SessionManager::open() {
+        Ok(m) => Some(m),
+        Err(e) => {
+            warn!("WinAudio session manager unavailable: {}", e);
+            None
+        },
+    };
+
+    // Register the volume-change callback. Must keep the COM reference
+    // alive in scope so the audio engine can call back into it; we
+    // unregister before drop.
+    let registered = endpoint.as_ref().and_then(|ep| {
+        let cb_impl = EndpointVolumeCallback::new(event_tx.clone());
+        let cb: IAudioEndpointVolumeCallback = cb_impl.into();
+        match unsafe { ep.iface().RegisterControlChangeNotify(&cb) } {
+            Ok(()) => {
+                debug!("RegisterControlChangeNotify succeeded");
+                Some(cb)
+            },
+            Err(e) => {
+                warn!("RegisterControlChangeNotify failed: {:?}", e);
+                None
+            },
+        }
+    });
+
+    // Push initial state so the X-Touch is in sync immediately.
+    if let Some(ep) = endpoint.as_ref() {
+        if let (Ok(scalar), Ok(mute)) = (ep.get_volume_scalar(), ep.get_mute()) {
+            let _ = event_tx.send(AudioEvent::MasterVolumeChanged { scalar, mute });
+        }
+    }
+
+    info!("WinAudio COM loop running");
+
+    while let Some(cmd) = cmd_rx.blocking_recv() {
+        match cmd {
+            AudioCmd::SetMasterScalar(scalar) => {
+                if let Some(ep) = endpoint.as_ref() {
+                    if let Err(e) = ep.set_volume_scalar(scalar) {
+                        warn!("set_volume_scalar({}) failed: {}", scalar, e);
+                    } else {
+                        let mute = ep.get_mute().unwrap_or(false);
+                        let _ = event_tx.send(AudioEvent::MasterVolumeChanged { scalar, mute });
+                    }
+                }
+            },
+            AudioCmd::ToggleMasterMute => {
+                if let Some(ep) = endpoint.as_ref() {
+                    let cur = ep.get_mute().unwrap_or(false);
+                    if let Err(e) = ep.set_mute(!cur) {
+                        warn!("set_mute failed: {}", e);
+                    } else {
+                        let scalar = ep.get_volume_scalar().unwrap_or(0.0);
+                        let _ =
+                            event_tx.send(AudioEvent::MasterVolumeChanged { scalar, mute: !cur });
+                    }
+                }
+            },
+            AudioCmd::RefreshMaster => {
+                if let Some(ep) = endpoint.as_ref() {
+                    if let (Ok(scalar), Ok(mute)) = (ep.get_volume_scalar(), ep.get_mute()) {
+                        let _ = event_tx.send(AudioEvent::MasterVolumeChanged { scalar, mute });
+                    }
+                }
+            },
+            AudioCmd::RefreshSessions => {
+                if let Some(mgr) = session_mgr.as_ref() {
+                    match mgr.enumerate() {
+                        Ok(sessions) => {
+                            for s in sessions {
+                                if s.process_name.is_empty() {
+                                    continue;
+                                }
+                                let scalar = unsafe { s.volume.GetMasterVolume().unwrap_or(0.0) };
+                                let mute = unsafe {
+                                    s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false)
+                                };
+                                let _ = event_tx.send(AudioEvent::SessionVolumeSnapshot {
+                                    process_name_lc: s.process_name,
+                                    scalar,
+                                    mute,
+                                });
+                            }
+                        },
+                        Err(e) => warn!("RefreshSessions enumerate failed: {}", e),
+                    }
+                }
+            },
+            AudioCmd::SetSessionScalar {
+                process_name_lc,
+                scalar,
+            } => {
+                if let Some(mgr) = session_mgr.as_ref() {
+                    match mgr.enumerate() {
+                        Ok(sessions) => {
+                            if let Some(s) =
+                                super::mapping::find_session(&sessions, &process_name_lc)
+                            {
+                                if let Err(e) = set_session_volume(s, scalar) {
+                                    warn!(
+                                        "SetSessionVolume({}, {}) failed: {}",
+                                        process_name_lc, scalar, e
+                                    );
+                                }
+                            } else {
+                                trace!(
+                                    "No active session for '{}'; ignoring volume command",
+                                    process_name_lc
+                                );
+                            }
+                        },
+                        Err(e) => warn!("session enumerate failed: {}", e),
+                    }
+                }
+            },
+            AudioCmd::ToggleSessionMute { process_name_lc } => {
+                if let Some(mgr) = session_mgr.as_ref() {
+                    match mgr.enumerate() {
+                        Ok(sessions) => {
+                            if let Some(s) =
+                                super::mapping::find_session(&sessions, &process_name_lc)
+                            {
+                                if let Err(e) = toggle_session_mute(s) {
+                                    warn!("ToggleSessionMute({}) failed: {}", process_name_lc, e);
+                                }
+                            }
+                        },
+                        Err(e) => warn!("session enumerate failed: {}", e),
+                    }
+                }
+            },
+            AudioCmd::EnumerateSessions { reply } => {
+                let names = session_mgr
+                    .as_ref()
+                    .and_then(|m| m.enumerate().ok())
+                    .map(|sessions| {
+                        sessions
+                            .into_iter()
+                            .map(|s| s.process_name)
+                            .filter(|n| !n.is_empty())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                let _ = reply.send(names);
+            },
+            AudioCmd::Shutdown => {
+                debug!("WinAudio COM loop shutting down");
+                break;
+            },
+        }
+    }
+
+    // Unregister the callback before dropping the endpoint.
+    if let (Some(ep), Some(cb)) = (endpoint.as_ref(), registered.as_ref()) {
+        if let Err(e) = unsafe { ep.iface().UnregisterControlChangeNotify(cb) } {
+            warn!("UnregisterControlChangeNotify failed: {:?}", e);
+        }
+    }
+    drop(registered);
+    drop(endpoint);
+    drop(session_mgr);
+    unsafe { CoUninitialize() };
+}

--- a/src/drivers/winaudio/mapping.rs
+++ b/src/drivers/winaudio/mapping.rs
@@ -118,6 +118,33 @@ pub fn pinned_target(pinned: &[PinnedApp], fader: u8) -> Option<String> {
         .map(|p| p.process_name.to_lowercase())
 }
 
+/// Reverse of [`pinned_target`] / [`discovered_target`]: given a session's
+/// process name, return the YAML target string (`"pinned:N"` or
+/// `"discovered:N"`) that pages bind to. Returns `None` if the session
+/// is neither pinned nor in the discovery FIFO.
+pub fn target_for_process(
+    pinned: &[PinnedApp],
+    discovery: &DiscoveryState,
+    process_name_lc: &str,
+) -> Option<String> {
+    if let Some(pin) = pinned
+        .iter()
+        .find(|p| p.process_name.to_lowercase() == process_name_lc)
+    {
+        return Some(format!("pinned:{}", pin.fader));
+    }
+    let pinned_lc: HashSet<String> = pinned
+        .iter()
+        .map(|p| p.process_name.to_lowercase())
+        .collect();
+    discovery
+        .discovered_order
+        .iter()
+        .filter(|n| !pinned_lc.contains(*n))
+        .position(|n| n == process_name_lc)
+        .map(|idx| format!("discovered:{}", idx))
+}
+
 /// Resolve a `discovered:N` slot to its current process name (according
 /// to `discovery`), skipping pinned names.
 pub fn discovered_target(
@@ -214,6 +241,31 @@ mod tests {
         // Oldest entries (app0..app17) should be evicted; app18..app49 retained.
         assert_eq!(s.discovered_order.first().unwrap(), "app18.exe");
         assert_eq!(s.discovered_order.last().unwrap(), "app49.exe");
+    }
+
+    #[test]
+    fn target_for_process_resolves_pinned_and_discovered() {
+        let pinned = vec![pin(1, "Discord.exe"), pin(3, "Spotify.exe")];
+        let discovery = DiscoveryState {
+            discovered_order: vec!["firefox.exe".into(), "msedge.exe".into()],
+        };
+        assert_eq!(
+            target_for_process(&pinned, &discovery, "discord.exe"),
+            Some("pinned:1".into())
+        );
+        assert_eq!(
+            target_for_process(&pinned, &discovery, "spotify.exe"),
+            Some("pinned:3".into())
+        );
+        assert_eq!(
+            target_for_process(&pinned, &discovery, "firefox.exe"),
+            Some("discovered:0".into())
+        );
+        assert_eq!(
+            target_for_process(&pinned, &discovery, "msedge.exe"),
+            Some("discovered:1".into())
+        );
+        assert_eq!(target_for_process(&pinned, &discovery, "unknown.exe"), None);
     }
 
     #[test]

--- a/src/drivers/winaudio/mapping.rs
+++ b/src/drivers/winaudio/mapping.rs
@@ -28,17 +28,26 @@ pub struct SlotBinding {
     pub display_name: String,
 }
 
+/// Hard cap on the FIFO discovery list. Only 8 fader slots exist; the
+/// extra headroom keeps a few "next in line" entries around so a session
+/// that briefly closes and re-opens reclaims its slot. Beyond this, the
+/// oldest entries are evicted to bound memory across long-running sessions
+/// where many short-lived audio sources come and go.
+const DISCOVERY_CAP: usize = 32;
+
 #[derive(Debug, Default, Clone)]
 pub struct DiscoveryState {
     /// Lowercase process names in first-seen order. Once added, names
     /// stay in the list — keeps fader assignments stable across
-    /// re-enumerations.
+    /// re-enumerations. Bounded by `DISCOVERY_CAP`; oldest entries are
+    /// evicted to make room for new arrivals.
     pub discovered_order: Vec<String>,
 }
 
 impl DiscoveryState {
     /// Push any newly seen process names (lowercase) to the end of the
     /// stable discovery order, skipping duplicates and pinned names.
+    /// Evicts the oldest entries when the list exceeds `DISCOVERY_CAP`.
     pub fn observe(&mut self, names_lc: &[String], pinned_lc: &HashSet<String>) {
         for name in names_lc {
             if pinned_lc.contains(name) {
@@ -47,6 +56,10 @@ impl DiscoveryState {
             if !self.discovered_order.iter().any(|s| s == name) {
                 self.discovered_order.push(name.clone());
             }
+        }
+        if self.discovered_order.len() > DISCOVERY_CAP {
+            let drop_count = self.discovered_order.len() - DISCOVERY_CAP;
+            self.discovered_order.drain(0..drop_count);
         }
     }
 }
@@ -188,6 +201,19 @@ mod tests {
         assert_eq!(by_slot[&2].process_name.as_deref(), Some("spotify.exe"));
         assert_eq!(by_slot[&5].process_name.as_deref(), Some("discord.exe"));
         assert_eq!(by_slot[&1].process_name.as_deref(), Some("firefox.exe"));
+    }
+
+    #[test]
+    fn discovery_caps_at_max_size() {
+        let mut s = DiscoveryState::default();
+        let pinned = HashSet::new();
+        // Push 50 unique names; expect only the last DISCOVERY_CAP (=32) to remain.
+        let names: Vec<String> = (0..50).map(|i| format!("app{i}.exe")).collect();
+        s.observe(&names, &pinned);
+        assert_eq!(s.discovered_order.len(), DISCOVERY_CAP);
+        // Oldest entries (app0..app17) should be evicted; app18..app49 retained.
+        assert_eq!(s.discovered_order.first().unwrap(), "app18.exe");
+        assert_eq!(s.discovered_order.last().unwrap(), "app49.exe");
     }
 
     #[test]

--- a/src/drivers/winaudio/mapping.rs
+++ b/src/drivers/winaudio/mapping.rs
@@ -1,0 +1,209 @@
+//! Map fader slots (1..=8) to concrete audio sessions.
+//!
+//! Two-pass resolution:
+//!   1. **Pinned** apps from `WinAudioConfig::pinned_apps` claim their
+//!      requested fader slot regardless of session activity.
+//!   2. **Discovered** sessions fill the remaining slots in FIFO discovery
+//!      order. The order is captured in `discovered_order` and is stable
+//!      across re-enumerations: a session is appended the first time we
+//!      see it and its position never moves, even if it temporarily
+//!      disappears and re-opens later.
+
+use std::collections::HashSet;
+
+use crate::config::PinnedApp;
+
+#[cfg(target_os = "windows")]
+use super::session::SessionInfo;
+
+/// Output of a single mapping pass: a concrete fader slot binding.
+#[derive(Debug, Clone)]
+pub struct SlotBinding {
+    /// 1..=8.
+    pub fader: u8,
+    /// Lowercase exe name (e.g. "discord.exe"), or `None` for a pinned slot
+    /// whose app isn't currently producing audio.
+    pub process_name: Option<String>,
+    /// Friendly LCD label.
+    pub display_name: String,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct DiscoveryState {
+    /// Lowercase process names in first-seen order. Once added, names
+    /// stay in the list — keeps fader assignments stable across
+    /// re-enumerations.
+    pub discovered_order: Vec<String>,
+}
+
+impl DiscoveryState {
+    /// Push any newly seen process names (lowercase) to the end of the
+    /// stable discovery order, skipping duplicates and pinned names.
+    pub fn observe(&mut self, names_lc: &[String], pinned_lc: &HashSet<String>) {
+        for name in names_lc {
+            if pinned_lc.contains(name) {
+                continue;
+            }
+            if !self.discovered_order.iter().any(|s| s == name) {
+                self.discovered_order.push(name.clone());
+            }
+        }
+    }
+}
+
+/// Compute the static mapping fader_slot → app from config and current
+/// discovery order. The result has at most 8 entries (one per fader).
+pub fn compute_slots(pinned: &[PinnedApp], discovery: &DiscoveryState) -> Vec<SlotBinding> {
+    let mut bindings: Vec<Option<SlotBinding>> = (0..8).map(|_| None).collect();
+
+    // 1. Pinned slots take priority.
+    let mut pinned_lc: HashSet<String> = HashSet::new();
+    for pin in pinned {
+        if !(1..=8).contains(&pin.fader) {
+            continue;
+        }
+        let name_lc = pin.process_name.to_lowercase();
+        let display = pin
+            .display_name
+            .clone()
+            .unwrap_or_else(|| derive_label(&pin.process_name));
+        bindings[(pin.fader - 1) as usize] = Some(SlotBinding {
+            fader: pin.fader,
+            process_name: Some(name_lc.clone()),
+            display_name: display,
+        });
+        pinned_lc.insert(name_lc);
+    }
+
+    // 2. Discovered sessions fill remaining slots in stable order.
+    let mut discovered_iter = discovery
+        .discovered_order
+        .iter()
+        .filter(|n| !pinned_lc.contains(*n));
+    for slot_idx in 0..8 {
+        if bindings[slot_idx].is_some() {
+            continue;
+        }
+        let Some(name_lc) = discovered_iter.next() else {
+            break;
+        };
+        bindings[slot_idx] = Some(SlotBinding {
+            fader: (slot_idx + 1) as u8,
+            process_name: Some(name_lc.clone()),
+            display_name: derive_label(name_lc),
+        });
+    }
+
+    bindings.into_iter().flatten().collect()
+}
+
+/// Resolve a `pinned:N` slot to its configured process name.
+pub fn pinned_target(pinned: &[PinnedApp], fader: u8) -> Option<String> {
+    pinned
+        .iter()
+        .find(|p| p.fader == fader)
+        .map(|p| p.process_name.to_lowercase())
+}
+
+/// Resolve a `discovered:N` slot to its current process name (according
+/// to `discovery`), skipping pinned names.
+pub fn discovered_target(
+    pinned: &[PinnedApp],
+    discovery: &DiscoveryState,
+    slot: u8,
+) -> Option<String> {
+    let pinned_lc: HashSet<String> = pinned
+        .iter()
+        .map(|p| p.process_name.to_lowercase())
+        .collect();
+    discovery
+        .discovered_order
+        .iter()
+        .filter(|n| !pinned_lc.contains(*n))
+        .nth(slot as usize)
+        .cloned()
+}
+
+/// Find a session info matching a process name (lowercase).
+#[cfg(target_os = "windows")]
+pub fn find_session<'a>(
+    sessions: &'a [SessionInfo],
+    process_name_lc: &str,
+) -> Option<&'a SessionInfo> {
+    sessions.iter().find(|s| s.process_name == process_name_lc)
+}
+
+fn derive_label(process_name: &str) -> String {
+    // Drop ".exe" suffix and capitalize the first letter for display.
+    let stem = process_name
+        .rsplit_once('.')
+        .map(|(s, _)| s)
+        .unwrap_or(process_name);
+    let mut chars = stem.chars();
+    match chars.next() {
+        Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PinnedApp;
+
+    fn pin(fader: u8, name: &str) -> PinnedApp {
+        PinnedApp {
+            fader,
+            process_name: name.to_string(),
+            display_name: None,
+        }
+    }
+
+    #[test]
+    fn discovery_appends_in_order() {
+        let mut s = DiscoveryState::default();
+        let pinned = HashSet::new();
+        s.observe(&["a.exe".into(), "b.exe".into()], &pinned);
+        s.observe(&["b.exe".into(), "c.exe".into()], &pinned);
+        assert_eq!(s.discovered_order, vec!["a.exe", "b.exe", "c.exe"]);
+    }
+
+    #[test]
+    fn discovery_skips_pinned() {
+        let mut s = DiscoveryState::default();
+        let pinned: HashSet<String> = ["b.exe".into()].into_iter().collect();
+        s.observe(&["a.exe".into(), "b.exe".into(), "c.exe".into()], &pinned);
+        assert_eq!(s.discovered_order, vec!["a.exe", "c.exe"]);
+    }
+
+    #[test]
+    fn pinned_keeps_their_slots() {
+        let pinned = vec![pin(2, "Spotify.exe"), pin(5, "Discord.exe")];
+        let discovery = DiscoveryState {
+            discovered_order: vec!["firefox.exe".into()],
+        };
+        let bindings = compute_slots(&pinned, &discovery);
+        let by_slot: std::collections::HashMap<_, _> =
+            bindings.iter().map(|b| (b.fader, b.clone())).collect();
+        assert_eq!(by_slot[&2].process_name.as_deref(), Some("spotify.exe"));
+        assert_eq!(by_slot[&5].process_name.as_deref(), Some("discord.exe"));
+        assert_eq!(by_slot[&1].process_name.as_deref(), Some("firefox.exe"));
+    }
+
+    #[test]
+    fn discovered_target_resolves_in_order() {
+        let pinned = vec![pin(1, "Discord.exe")];
+        let discovery = DiscoveryState {
+            discovered_order: vec!["spotify.exe".into(), "firefox.exe".into()],
+        };
+        assert_eq!(
+            discovered_target(&pinned, &discovery, 0),
+            Some("spotify.exe".into())
+        );
+        assert_eq!(
+            discovered_target(&pinned, &discovery, 1),
+            Some("firefox.exe".into())
+        );
+        assert_eq!(discovered_target(&pinned, &discovery, 2), None);
+    }
+}

--- a/src/drivers/winaudio/master.rs
+++ b/src/drivers/winaudio/master.rs
@@ -1,0 +1,84 @@
+//! Default render endpoint master volume / mute wrapper.
+//!
+//! Wraps `IMMDeviceEnumerator -> IMMDevice -> IAudioEndpointVolume` for the
+//! default audio render endpoint (eRender, eConsole). All methods are
+//! synchronous and must be invoked on a thread that has called
+//! `CoInitializeEx(COINIT_APARTMENTTHREADED)`.
+
+#![cfg(target_os = "windows")]
+
+use anyhow::{Context, Result};
+use windows::core::Interface;
+use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
+use windows::Win32::Media::Audio::{eConsole, eRender, IMMDeviceEnumerator, MMDeviceEnumerator};
+use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
+
+pub struct MasterEndpoint {
+    iface: IAudioEndpointVolume,
+}
+
+impl MasterEndpoint {
+    pub fn open() -> Result<Self> {
+        unsafe {
+            let enumerator: IMMDeviceEnumerator =
+                CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                    .context("CoCreateInstance(MMDeviceEnumerator)")?;
+            let device = enumerator
+                .GetDefaultAudioEndpoint(eRender, eConsole)
+                .context("GetDefaultAudioEndpoint(eRender, eConsole)")?;
+            let iface: IAudioEndpointVolume = device
+                .Activate(CLSCTX_ALL, None)
+                .context("Activate IAudioEndpointVolume")?;
+            Ok(Self { iface })
+        }
+    }
+
+    pub fn set_volume_scalar(&self, scalar: f32) -> Result<()> {
+        let clamped = scalar.clamp(0.0, 1.0);
+        unsafe {
+            self.iface
+                .SetMasterVolumeLevelScalar(clamped, std::ptr::null())
+                .context("SetMasterVolumeLevelScalar")?;
+        }
+        Ok(())
+    }
+
+    pub fn get_volume_scalar(&self) -> Result<f32> {
+        unsafe {
+            self.iface
+                .GetMasterVolumeLevelScalar()
+                .context("GetMasterVolumeLevelScalar")
+        }
+    }
+
+    pub fn set_mute(&self, mute: bool) -> Result<()> {
+        unsafe {
+            self.iface
+                .SetMute(mute, std::ptr::null())
+                .context("SetMute")?;
+        }
+        Ok(())
+    }
+
+    pub fn get_mute(&self) -> Result<bool> {
+        unsafe { Ok(self.iface.GetMute().context("GetMute")?.as_bool()) }
+    }
+
+    /// Expose the underlying interface as a downcastable handle (used by
+    /// the callback module to register `IAudioEndpointVolumeCallback`).
+    pub fn iface(&self) -> &IAudioEndpointVolume {
+        &self.iface
+    }
+}
+
+// Note: `IAudioEndpointVolume` is `!Send` / `!Sync` by default; this struct
+// must remain confined to the COM thread. The compiler enforces this — we
+// do not add explicit Send/Sync impls.
+#[allow(dead_code)]
+const _ASSERT_NOT_SEND: fn() = || {
+    fn require_not_send<T: ?Sized>(_: &T)
+    where
+        T: Interface,
+    {
+    }
+};

--- a/src/drivers/winaudio/master.rs
+++ b/src/drivers/winaudio/master.rs
@@ -8,7 +8,6 @@
 #![cfg(target_os = "windows")]
 
 use anyhow::{Context, Result};
-use windows::core::Interface;
 use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
 use windows::Win32::Media::Audio::{eConsole, eRender, IMMDeviceEnumerator, MMDeviceEnumerator};
 use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
@@ -70,15 +69,3 @@ impl MasterEndpoint {
         &self.iface
     }
 }
-
-// Note: `IAudioEndpointVolume` is `!Send` / `!Sync` by default; this struct
-// must remain confined to the COM thread. The compiler enforces this — we
-// do not add explicit Send/Sync impls.
-#[allow(dead_code)]
-const _ASSERT_NOT_SEND: fn() = || {
-    fn require_not_send<T: ?Sized>(_: &T)
-    where
-        T: Interface,
-    {
-    }
-};

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -98,6 +98,7 @@ impl Driver for WinAudioDriver {
                                 feedback,
                                 self.config.clone(),
                                 self.discovery.clone(),
+                                self.router.clone(),
                             ));
                         } else {
                             warn!(
@@ -373,17 +374,6 @@ async fn refresh_full_state(
     handle.refresh_sessions();
 }
 
-/// MCU note number for `mute<N>` button on strip `N` (1..=8). The
-/// X-Touch maps mute1→16, mute2→17, …, mute8→23. See
-/// `docs/xtouch-matching.csv`.
-const MUTE_NOTE_BASE: u8 = 15;
-
-/// Resolve the configured master-fader strip (`1..=9`) to a 0-based MIDI
-/// channel: regular strips 1..=8 → channels 0..=7, master strip 9 → 8.
-fn master_fader_channel0(master_fader: u8) -> u8 {
-    master_fader.saturating_sub(1).min(8)
-}
-
 /// Convert a raw 14-bit PitchBend value from the router into a `[0.0, 1.0]`
 /// scalar. The router forwards `ctx.value` verbatim as the integer 14-bit
 /// reading.
@@ -418,32 +408,49 @@ mod normalize_tests {
     }
 }
 
+/// Logical winaudio action key used to dedup events in the coalesce
+/// buffer. Each tuple maps to at most one fader/LED on the active page;
+/// any matching action+target rebinding in YAML is honored without code
+/// changes.
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum FeedbackKey {
+    Master,
+    /// Session slot target string, e.g. `"pinned:1"` or `"discovered:0"`.
+    Session(String),
+}
+
+#[cfg(target_os = "windows")]
+struct PendingFeedback {
+    scalar: f32,
+    mute: bool,
+}
+
 /// Pump `AudioEvent`s emitted by the COM thread into the router's
 /// unified feedback channel as synthetic `"winaudio"` MIDI messages.
 ///
-/// This lets the existing feedback pipeline (anti-echo, fader_setpoint,
-/// state actor, page-aware filtering) handle Windows audio updates the
-/// same way it handles OBS / Voicemeeter feedback — no special-casing
-/// in the router.
-///
-/// `config` and `discovery` are read on each flush tick to resolve
-/// process names to fader slots, so the consumer always reflects the
-/// current pinned/discovered mapping.
+/// **Mapping resolution:** the consumer reads the active page YAML and
+/// the canonical `control_mapping.csv` to resolve which X-Touch control
+/// (and therefore which MIDI channel/note) carries each `winaudio`
+/// action. There is no hardcoded fader/note assumption in the driver —
+/// pages can rebind master/session controls freely and the feedback
+/// follows.
 ///
 /// **Coalescing:** the OS audio engine fires `OnSimpleVolumeChanged`
 /// once per intermediate value while the user drags the Windows mixer
 /// slider. Sending each one as a discrete fader command makes the
 /// motorized fader chase every step instead of jumping to the final
-/// position. We buffer the latest `(scalar, mute)` per channel and
-/// flush at `FLUSH_INTERVAL_MS`, which lets the motor settle on the
-/// final value while keeping perceived latency well under the
-/// 50 ms feel threshold.
+/// position. We buffer the latest `(scalar, mute)` per logical action
+/// and flush at `FLUSH_INTERVAL_MS`, which lets the motor settle on the
+/// final value while keeping perceived latency well under the 50 ms
+/// feel threshold.
 #[cfg(target_os = "windows")]
 async fn run_event_consumer(
     mut event_rx: mpsc::Receiver<com_thread::AudioEvent>,
     feedback_tx: mpsc::Sender<(String, Vec<u8>)>,
     config: Arc<RwLock<WinAudioConfig>>,
     discovery: Arc<RwLock<mapping::DiscoveryState>>,
+    router: Arc<RwLock<Option<Arc<crate::router::Router>>>>,
 ) {
     use std::collections::HashMap;
     use tokio::time::{interval, Duration, MissedTickBehavior};
@@ -454,12 +461,7 @@ async fn run_event_consumer(
 
     debug!("WinAudio event consumer task started");
 
-    // Per-channel buffer of the latest pending feedback. Keyed by the
-    // 0-based MIDI channel of the fader; sub-channel state is the
-    // (scalar, mute_note, mute_bool) triple we'd otherwise have sent.
-    // Inserting overwrites the previous pending value — that's the
-    // coalesce.
-    let mut pending: HashMap<u8, PendingFeedback> = HashMap::new();
+    let mut pending: HashMap<FeedbackKey, PendingFeedback> = HashMap::new();
 
     let mut ticker = interval(Duration::from_millis(FLUSH_INTERVAL_MS));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -478,52 +480,29 @@ async fn run_event_consumer(
                 if pending.is_empty() {
                     continue;
                 }
-                for (channel0, p) in pending.drain() {
-                    if !emit_volume_and_mute(
-                        &feedback_tx, channel0, p.scalar, p.mute_note, p.mute,
-                    )
-                    .await
-                    {
-                        debug!("WinAudio feedback channel closed, exiting consumer");
-                        return;
-                    }
+                let drained: Vec<(FeedbackKey, PendingFeedback)> = pending.drain().collect();
+                if !flush_pending(&drained, &feedback_tx, &router).await {
+                    debug!("WinAudio feedback channel closed, exiting consumer");
+                    return;
                 }
             }
         }
     }
 }
 
-#[cfg(target_os = "windows")]
-struct PendingFeedback {
-    scalar: f32,
-    mute_note: u8,
-    mute: bool,
-}
-
-/// Resolve an `AudioEvent` to a `(channel0, payload)` and stash it in
-/// the coalesce buffer. Out-of-mapping events (snapshots for sessions
-/// that don't have a fader slot) are dropped silently.
+/// Stash an event into the coalesce buffer. Sessions are keyed by their
+/// resolved YAML target (`pinned:N` / `discovered:N`); unresolvable
+/// sessions are dropped silently.
 #[cfg(target_os = "windows")]
 async fn buffer_event(
-    pending: &mut std::collections::HashMap<u8, PendingFeedback>,
+    pending: &mut std::collections::HashMap<FeedbackKey, PendingFeedback>,
     event: com_thread::AudioEvent,
     config: &Arc<RwLock<WinAudioConfig>>,
     discovery: &Arc<RwLock<mapping::DiscoveryState>>,
 ) {
     match event {
         com_thread::AudioEvent::MasterVolumeChanged { scalar, mute } => {
-            let cfg = config.read().await;
-            let channel0 = master_fader_channel0(cfg.master_fader);
-            let mute_note = cfg.master_mute_note;
-            drop(cfg);
-            pending.insert(
-                channel0,
-                PendingFeedback {
-                    scalar,
-                    mute_note,
-                    mute,
-                },
-            );
+            pending.insert(FeedbackKey::Master, PendingFeedback { scalar, mute });
         },
         com_thread::AudioEvent::SessionVolumeSnapshot {
             process_name_lc,
@@ -532,66 +511,174 @@ async fn buffer_event(
         } => {
             let cfg = config.read().await;
             let disc = discovery.read().await;
-            let slots = mapping::compute_slots(&cfg.pinned_apps, &disc);
-            let Some(binding) = slots
-                .iter()
-                .find(|b| b.process_name.as_deref() == Some(process_name_lc.as_str()))
-            else {
-                drop(disc);
-                drop(cfg);
+            let target = mapping::target_for_process(&cfg.pinned_apps, &disc, &process_name_lc);
+            drop(disc);
+            drop(cfg);
+            let Some(target) = target else {
                 debug!(
                     "session snapshot for '{}' has no fader slot, ignored",
                     process_name_lc
                 );
                 return;
             };
-            let fader = binding.fader;
-            drop(disc);
-            drop(cfg);
-
-            // session<N> on strip N → fader channel N-1, mute Note N+15.
-            let channel0 = fader.saturating_sub(1);
-            let mute_note = MUTE_NOTE_BASE + fader.clamp(1, 8);
             pending.insert(
-                channel0,
-                PendingFeedback {
-                    scalar,
-                    mute_note,
-                    mute,
-                },
+                FeedbackKey::Session(target),
+                PendingFeedback { scalar, mute },
             );
         },
     }
 }
 
-/// Emit a paired PitchBend (volume) + Note On/Off (mute LED) feedback
-/// for a single strip. Returns `false` if the feedback channel is
-/// closed, so the caller can exit its loop.
+/// Resolve every pending event to MIDI bytes (via active page +
+/// `control_mapping.csv`) and emit them. Returns `false` if the
+/// feedback channel is closed.
 #[cfg(target_os = "windows")]
-async fn emit_volume_and_mute(
+async fn flush_pending(
+    drained: &[(FeedbackKey, PendingFeedback)],
     feedback_tx: &mpsc::Sender<(String, Vec<u8>)>,
-    channel0: u8,
-    scalar: f32,
-    mute_note: u8,
-    mute: bool,
+    router: &Arc<RwLock<Option<Arc<crate::router::Router>>>>,
 ) -> bool {
-    let pb = pitchbend_bytes(channel0, scalar);
-    if feedback_tx
-        .send((DRIVER_NAME.to_string(), pb))
-        .await
-        .is_err()
-    {
-        return false;
-    }
-    let note = mute_note_bytes(mute_note, mute);
-    if feedback_tx
-        .send((DRIVER_NAME.to_string(), note))
-        .await
-        .is_err()
-    {
-        return false;
+    let Some(router_arc) = router.read().await.clone() else {
+        debug!(
+            "WinAudio flush: no router wired, dropping {} event(s)",
+            drained.len()
+        );
+        return true;
+    };
+    let Some(page) = router_arc.get_active_page().await else {
+        return true;
+    };
+    let mcu_mode = is_mcu_mode(&router_arc).await;
+
+    let Ok(db) = crate::control_mapping::load_default_mappings() else {
+        warn!("WinAudio flush: control_mapping DB unavailable");
+        return true;
+    };
+
+    for (key, p) in drained {
+        let (volume_action, mute_action, target) = match key {
+            FeedbackKey::Master => ("master_volume", "master_mute", None),
+            FeedbackKey::Session(t) => ("session_volume", "session_mute", Some(t.as_str())),
+        };
+
+        // Volume → PitchBend or CC.
+        if let Some(spec) = resolve_action_spec(&page, volume_action, target, db, mcu_mode) {
+            let bytes = bytes_for_volume(&spec, p.scalar);
+            if !try_send(feedback_tx, bytes).await {
+                return false;
+            }
+        }
+
+        // Mute → Note (LED).
+        if let Some(spec) = resolve_action_spec(&page, mute_action, target, db, mcu_mode) {
+            let bytes = bytes_for_mute(&spec, p.mute);
+            if !try_send(feedback_tx, bytes).await {
+                return false;
+            }
+        }
     }
     true
+}
+
+#[cfg(target_os = "windows")]
+async fn is_mcu_mode(router: &Arc<crate::router::Router>) -> bool {
+    let cfg = router.config.read().await;
+    cfg.xtouch
+        .as_ref()
+        .map(|x| matches!(x.mode, crate::config::XTouchMode::Mcu))
+        .unwrap_or(true)
+}
+
+/// Find the page control bound to `(action, target)` and resolve it to
+/// a hardware MIDI spec via `control_mapping.csv`. Page controls are
+/// checked first, then global controls.
+#[cfg(target_os = "windows")]
+fn resolve_action_spec(
+    page: &crate::config::PageConfig,
+    action: &str,
+    target: Option<&str>,
+    db: &crate::control_mapping::ControlMappingDB,
+    mcu_mode: bool,
+) -> Option<crate::control_mapping::MidiSpec> {
+    let control_id = find_winaudio_control_id(page, action, target)?;
+    db.get_midi_spec(&control_id, mcu_mode)
+}
+
+#[cfg(target_os = "windows")]
+fn find_winaudio_control_id(
+    page: &crate::config::PageConfig,
+    action: &str,
+    target: Option<&str>,
+) -> Option<String> {
+    let controls = page.controls.as_ref()?;
+    controls
+        .iter()
+        .find(|(_, m)| {
+            m.app == DRIVER_NAME
+                && m.action.as_deref() == Some(action)
+                && match target {
+                    None => true,
+                    Some(want) => {
+                        m.params
+                            .as_ref()
+                            .and_then(|p| p.first())
+                            .and_then(|v| v.as_str())
+                            == Some(want)
+                    },
+                }
+        })
+        .map(|(id, _)| id.clone())
+}
+
+#[cfg(target_os = "windows")]
+fn bytes_for_volume(spec: &crate::control_mapping::MidiSpec, scalar: f32) -> Vec<u8> {
+    use crate::control_mapping::MidiSpec;
+    use crate::midi::{convert, MidiMessage};
+    let scalar = scalar.clamp(0.0, 1.0) as f64;
+    match *spec {
+        MidiSpec::PitchBend { channel } => MidiMessage::PitchBend {
+            channel: channel & 0x0F,
+            value: convert::denormalize_to_14bit(scalar),
+        }
+        .to_bytes(),
+        MidiSpec::ControlChange { cc } => MidiMessage::ControlChange {
+            channel: 0,
+            cc,
+            value: convert::denormalize_to_7bit(scalar),
+        }
+        .to_bytes(),
+        MidiSpec::Note { note } => mute_note_bytes(note, scalar > 0.0),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn bytes_for_mute(spec: &crate::control_mapping::MidiSpec, muted: bool) -> Vec<u8> {
+    use crate::control_mapping::MidiSpec;
+    match *spec {
+        MidiSpec::Note { note } => mute_note_bytes(note, muted),
+        // Some surfaces wire mute to a CC indicator instead of a note.
+        MidiSpec::ControlChange { cc } => crate::midi::MidiMessage::ControlChange {
+            channel: 0,
+            cc,
+            value: if muted { 127 } else { 0 },
+        }
+        .to_bytes(),
+        // PitchBend doesn't make sense for mute LEDs, but emit something
+        // sane rather than panicking.
+        MidiSpec::PitchBend { channel } => crate::midi::MidiMessage::PitchBend {
+            channel: channel & 0x0F,
+            value: if muted { 16383 } else { 0 },
+        }
+        .to_bytes(),
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn try_send(feedback_tx: &mpsc::Sender<(String, Vec<u8>)>, raw: Vec<u8>) -> bool {
+    feedback_tx
+        .send((DRIVER_NAME.to_string(), raw))
+        .await
+        .is_ok()
 }
 
 /// X-Touch button-LED convention: always `NoteOn`, with velocity 127 to
@@ -603,14 +690,6 @@ fn mute_note_bytes(note: u8, muted: bool) -> Vec<u8> {
         channel: 0,
         note,
         velocity: if muted { 127 } else { 0 },
-    }
-    .to_bytes()
-}
-
-fn pitchbend_bytes(channel0: u8, scalar: f32) -> Vec<u8> {
-    crate::midi::MidiMessage::PitchBend {
-        channel: channel0 & 0x0F,
-        value: crate::midi::convert::denormalize_to_14bit(scalar.clamp(0.0, 1.0) as f64),
     }
     .to_bytes()
 }

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -371,9 +371,26 @@ async fn refresh_full_state(
     handle.refresh_sessions();
 }
 
-/// MIDI channel (0-based) the master fader lives on, in MCU mode.
-/// Channel 9 (1-based) is the master strip, encoded as 0x08 internally.
-const MASTER_FADER_CHANNEL_0BASED: u8 = 8;
+/// MCU note number for `mute<N>` button on strip `N` (1..=8). The
+/// X-Touch maps mute1→16, mute2→17, …, mute8→23. See
+/// `docs/xtouch-matching.csv`.
+const MUTE_NOTE_BASE: u8 = 15;
+
+/// Resolve the configured master-fader strip (`1..=9`) to a 0-based MIDI
+/// channel: regular strips 1..=8 → channels 0..=7, master strip 9 → 8.
+fn master_fader_channel0(master_fader: u8) -> u8 {
+    master_fader.saturating_sub(1).min(8)
+}
+
+/// Resolve which mute button (Note number on channel 0) carries the
+/// master-mute LED. Mirrors `master_fader_channel0`: regular strips
+/// 1..=8 → mute notes 16..=23. The dedicated master strip (9) has no
+/// dedicated mute button on the X-Touch surface, so we fall back to
+/// `mute8` in that case.
+fn master_mute_note(master_fader: u8) -> u8 {
+    let strip = master_fader.clamp(1, 8);
+    MUTE_NOTE_BASE + strip
+}
 
 /// Convert a raw 14-bit PitchBend value from the router into a `[0.0, 1.0]`
 /// scalar. The router forwards `ctx.value` verbatim as the integer 14-bit
@@ -430,13 +447,11 @@ async fn run_event_consumer(
     debug!("WinAudio event consumer task started");
     while let Some(event) = event_rx.recv().await {
         match event {
-            com_thread::AudioEvent::MasterVolumeChanged { scalar, mute: _ } => {
-                let raw = pitchbend_bytes(MASTER_FADER_CHANNEL_0BASED, scalar);
-                if feedback_tx
-                    .send((DRIVER_NAME.to_string(), raw))
-                    .await
-                    .is_err()
-                {
+            com_thread::AudioEvent::MasterVolumeChanged { scalar, mute } => {
+                let master_fader = config.read().await.master_fader;
+                let channel0 = master_fader_channel0(master_fader);
+                let mute_note = master_mute_note(master_fader);
+                if !emit_volume_and_mute(&feedback_tx, channel0, scalar, mute_note, mute).await {
                     debug!("WinAudio feedback channel closed, exiting consumer");
                     break;
                 }
@@ -444,7 +459,7 @@ async fn run_event_consumer(
             com_thread::AudioEvent::SessionVolumeSnapshot {
                 process_name_lc,
                 scalar,
-                mute: _,
+                mute,
             } => {
                 // Resolve the fader slot this session currently occupies.
                 let cfg = config.read().await;
@@ -462,21 +477,68 @@ async fn run_event_consumer(
                     );
                     continue;
                 };
-                let channel0 = binding.fader.saturating_sub(1);
+                let fader = binding.fader;
                 drop(disc);
                 drop(cfg);
 
-                let raw = pitchbend_bytes(channel0, scalar);
-                if feedback_tx
-                    .send((DRIVER_NAME.to_string(), raw))
-                    .await
-                    .is_err()
-                {
+                // session<N> on strip N → fader channel N-1, mute Note N+15.
+                let channel0 = fader.saturating_sub(1);
+                let mute_note = MUTE_NOTE_BASE + fader.clamp(1, 8);
+                if !emit_volume_and_mute(&feedback_tx, channel0, scalar, mute_note, mute).await {
                     break;
                 }
             },
         }
     }
+}
+
+/// Emit a paired PitchBend (volume) + Note On/Off (mute LED) feedback
+/// for a single strip. Returns `false` if the feedback channel is
+/// closed, so the caller can exit its loop.
+#[cfg(target_os = "windows")]
+async fn emit_volume_and_mute(
+    feedback_tx: &mpsc::Sender<(String, Vec<u8>)>,
+    channel0: u8,
+    scalar: f32,
+    mute_note: u8,
+    mute: bool,
+) -> bool {
+    let pb = pitchbend_bytes(channel0, scalar);
+    if feedback_tx
+        .send((DRIVER_NAME.to_string(), pb))
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    let note = mute_note_bytes(mute_note, mute);
+    if feedback_tx
+        .send((DRIVER_NAME.to_string(), note))
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    true
+}
+
+/// MCU mute-LED convention: Note On (velocity 0x7F) = lit (muted), Note
+/// Off = unlit. Buttons live on MIDI channel 0.
+fn mute_note_bytes(note: u8, muted: bool) -> Vec<u8> {
+    let msg = if muted {
+        crate::midi::MidiMessage::NoteOn {
+            channel: 0,
+            note,
+            velocity: 0x7F,
+        }
+    } else {
+        crate::midi::MidiMessage::NoteOff {
+            channel: 0,
+            note,
+            velocity: 0,
+        }
+    };
+    msg.to_bytes()
 }
 
 fn pitchbend_bytes(channel0: u8, scalar: f32) -> Vec<u8> {

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -19,6 +19,8 @@ mod mapping;
 mod master;
 #[cfg(target_os = "windows")]
 mod session;
+#[cfg(target_os = "windows")]
+mod session_events;
 
 use crate::config::WinAudioConfig;
 use crate::drivers::{Driver, ExecutionContext};

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -1,0 +1,502 @@
+//! Windows audio driver: master + per-app session volume/mute control.
+//!
+//! Backed by Win32 Core Audio (`IMMDeviceEnumerator`, `IAudioEndpointVolume`,
+//! `IAudioSessionManager2`, `ISimpleAudioVolume`) and registered COM event
+//! callbacks for bidirectional sync. All COM work runs on a dedicated STA
+//! thread owned by the driver; the public surface is async and crosses
+//! the thread boundary via `mpsc` / `broadcast` channels.
+//!
+//! On non-Windows targets this driver is a no-op stub that logs every
+//! action — useful for testing the YAML routing path without hardware.
+
+mod actions;
+#[cfg(target_os = "windows")]
+mod callback;
+#[cfg(target_os = "windows")]
+mod com_thread;
+mod mapping;
+#[cfg(target_os = "windows")]
+mod master;
+#[cfg(target_os = "windows")]
+mod session;
+
+use crate::config::WinAudioConfig;
+use crate::drivers::{Driver, ExecutionContext};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+use tracing::{debug, info, warn};
+
+pub use actions::{parse_session_target, SessionTarget};
+
+/// Driver name used for `app: "winaudio"` in YAML control mappings.
+pub const DRIVER_NAME: &str = "winaudio";
+
+pub struct WinAudioDriver {
+    /// Pinned-app + (later) discovered-session configuration cloned from AppConfig.
+    config: Arc<RwLock<WinAudioConfig>>,
+    /// Set by `init`, cleared by `shutdown`.
+    initialized: Arc<RwLock<bool>>,
+    /// Optional Router handle for emitting LCD updates and reading state.
+    /// Wired post-construction via [`WinAudioDriver::set_router`].
+    router: Arc<RwLock<Option<Arc<crate::router::Router>>>>,
+    /// Optional feedback channel; wired post-construction. The COM event
+    /// consumer task uses this to inject synthetic feedback messages
+    /// (`("winaudio", raw_midi)`) into the unified router feedback path.
+    feedback_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<u8>)>>>>,
+    /// Stable discovery order of non-pinned process names. Updated whenever
+    /// we re-enumerate; never reorders existing entries.
+    discovery: Arc<RwLock<mapping::DiscoveryState>>,
+    #[cfg(target_os = "windows")]
+    com: Arc<RwLock<Option<com_thread::ComThreadHandle>>>,
+}
+
+impl WinAudioDriver {
+    pub fn new(config: WinAudioConfig) -> Self {
+        Self {
+            config: Arc::new(RwLock::new(config)),
+            initialized: Arc::new(RwLock::new(false)),
+            router: Arc::new(RwLock::new(None)),
+            feedback_tx: Arc::new(RwLock::new(None)),
+            discovery: Arc::new(RwLock::new(mapping::DiscoveryState::default())),
+            #[cfg(target_os = "windows")]
+            com: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Wire the driver to the router so it can push LCD updates.
+    /// Called by driver_setup after construction.
+    pub async fn set_router(&self, router: Arc<crate::router::Router>) {
+        *self.router.write().await = Some(router);
+    }
+
+    /// Wire the driver to the unified feedback channel.
+    pub async fn set_feedback_sender(&self, tx: mpsc::Sender<(String, Vec<u8>)>) {
+        *self.feedback_tx.write().await = Some(tx);
+    }
+}
+
+#[async_trait]
+impl Driver for WinAudioDriver {
+    fn name(&self) -> &str {
+        DRIVER_NAME
+    }
+
+    async fn init(&self, _ctx: ExecutionContext) -> Result<()> {
+        info!("WinAudio driver initializing");
+        #[cfg(target_os = "windows")]
+        {
+            match com_thread::ComThreadHandle::spawn() {
+                Ok(handle) => {
+                    info!("WinAudio COM thread started");
+                    if let Some(event_rx) = handle.take_event_rx().await {
+                        let feedback = self.feedback_tx.read().await.clone();
+                        if let Some(feedback) = feedback {
+                            tokio::spawn(run_event_consumer(
+                                event_rx,
+                                feedback,
+                                self.config.clone(),
+                                self.discovery.clone(),
+                            ));
+                        } else {
+                            warn!(
+                                "WinAudio: no feedback sender wired; volume changes won't reach the X-Touch"
+                            );
+                        }
+                    }
+
+                    // Initial discovery snapshot so `discovered:N` slots
+                    // are populated before the user moves a fader.
+                    self.refresh_discovery_with(&handle).await;
+
+                    *self.com.write().await = Some(handle);
+
+                    // Subscribe to page changes so we re-emit master state
+                    // every time "Windows Audio" becomes active.
+                    self.spawn_page_watcher().await;
+
+                    // Initial state push, after a short delay so the
+                    // VM auto-switch (poll every 5s, but first tick is
+                    // immediate) has a chance to land us on the right
+                    // page. The page filter inside the router would
+                    // otherwise drop a feedback emit while we're still
+                    // on "Voicemeeter+QLC".
+                    let com = self.com.clone();
+                    let cfg = self.config.clone();
+                    let disc = self.discovery.clone();
+                    tokio::spawn(async move {
+                        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+                        refresh_full_state(&com, &cfg, &disc).await;
+                    });
+                },
+                Err(e) => {
+                    warn!(
+                        "WinAudio COM thread failed to start: {} — driver will be inert",
+                        e
+                    );
+                },
+            }
+        }
+        *self.initialized.write().await = true;
+        Ok(())
+    }
+
+    async fn execute(&self, action: &str, params: Vec<Value>, ctx: ExecutionContext) -> Result<()> {
+        if !*self.initialized.read().await {
+            warn!(
+                "WinAudio driver not initialized, dropping action '{}'",
+                action
+            );
+            return Ok(());
+        }
+
+        // X-Touch faders deliver 14-bit PitchBend values (0..=16383); the
+        // router forwards the raw integer in `ctx.value`. Normalize here
+        // for *_volume actions so 100% Windows volume corresponds to a
+        // fully-up fader, not just any non-zero value.
+        let fader_scalar = ctx
+            .value
+            .as_ref()
+            .and_then(|v| v.as_f64())
+            .map(normalize_fader_value);
+
+        match action {
+            "master_volume" => self.handle_master_volume(fader_scalar).await,
+            "master_mute" => self.handle_master_mute(ctx.is_button_release()).await,
+            "session_volume" => {
+                let target = parse_session_target(&params)?;
+                self.handle_session_volume(target, fader_scalar).await
+            },
+            "session_mute" => {
+                let target = parse_session_target(&params)?;
+                self.handle_session_mute(target, ctx.is_button_release())
+                    .await
+            },
+            _ => {
+                warn!("Unknown winaudio action '{}'", action);
+                Ok(())
+            },
+        }
+    }
+
+    async fn sync(&self) -> Result<()> {
+        // Future: rebuild pinned/discovered mapping from new config.
+        debug!("WinAudio sync requested (no-op for now)");
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        *self.initialized.write().await = false;
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(handle) = self.com.write().await.take() {
+                handle.shutdown().await;
+            }
+        }
+        info!("WinAudio driver shut down");
+        Ok(())
+    }
+}
+
+impl WinAudioDriver {
+    async fn handle_master_volume(&self, normalized: Option<f32>) -> Result<()> {
+        let Some(scalar) = normalized else {
+            debug!("master_volume: no value, ignored");
+            return Ok(());
+        };
+        debug!("master_volume <- {:.3}", scalar);
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(com) = self.com.read().await.as_ref() {
+                com.set_master_scalar(scalar);
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_master_mute(&self, is_release: bool) -> Result<()> {
+        if is_release {
+            return Ok(());
+        }
+        debug!("master_mute toggle (press)");
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(com) = self.com.read().await.as_ref() {
+                com.toggle_master_mute();
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_session_volume(
+        &self,
+        target: SessionTarget,
+        normalized: Option<f32>,
+    ) -> Result<()> {
+        let Some(scalar) = normalized else {
+            return Ok(());
+        };
+        let Some(process_name_lc) = self.resolve_target(target).await else {
+            debug!("session_volume {:?}: no process bound", target);
+            return Ok(());
+        };
+        debug!("session_volume {} <- {:.3}", process_name_lc, scalar);
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(com) = self.com.read().await.as_ref() {
+                com.set_session_scalar(process_name_lc, scalar);
+            }
+        }
+        let _ = scalar; // silence unused warning on non-windows
+        Ok(())
+    }
+
+    async fn handle_session_mute(&self, target: SessionTarget, is_release: bool) -> Result<()> {
+        if is_release {
+            return Ok(());
+        }
+        let Some(process_name_lc) = self.resolve_target(target).await else {
+            return Ok(());
+        };
+        debug!("session_mute {} toggle", process_name_lc);
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(com) = self.com.read().await.as_ref() {
+                com.toggle_session_mute(process_name_lc);
+            }
+        }
+        Ok(())
+    }
+
+    async fn resolve_target(&self, target: SessionTarget) -> Option<String> {
+        let cfg = self.config.read().await;
+        match target {
+            SessionTarget::Pinned(fader) => mapping::pinned_target(&cfg.pinned_apps, fader),
+            SessionTarget::Discovered(slot) => {
+                let discovery = self.discovery.read().await;
+                mapping::discovered_target(&cfg.pinned_apps, &discovery, slot)
+            },
+        }
+    }
+
+    /// Spawn a background task that re-emits master + per-session state
+    /// whenever the "Windows Audio" page becomes active. Necessary
+    /// because the `IAudioEndpointVolumeCallback` only fires on actual
+    /// volume *changes*, never on page activation — so without this
+    /// the X-Touch fader stays at its old position the first time
+    /// the user switches to the Windows Audio page.
+    async fn spawn_page_watcher(&self) {
+        let router_arc = self.router.read().await.clone();
+        let Some(router) = router_arc else {
+            debug!("WinAudio: no router wired, skipping page watcher");
+            return;
+        };
+        let Some(live_tx) = router.live_tx_snapshot().await else {
+            debug!("WinAudio: live_tx not yet wired, skipping page watcher");
+            return;
+        };
+        let mut rx = live_tx.subscribe();
+        #[cfg(target_os = "windows")]
+        let com = self.com.clone();
+        #[cfg(target_os = "windows")]
+        let config = self.config.clone();
+        #[cfg(target_os = "windows")]
+        let discovery = self.discovery.clone();
+        tokio::spawn(async move {
+            while let Ok(event) = rx.recv().await {
+                if let crate::event_bus::LiveEvent::PageChanged { name, .. } = event {
+                    if name == "Windows Audio" {
+                        debug!("WinAudio: page activated, refreshing master + sessions");
+                        #[cfg(target_os = "windows")]
+                        {
+                            refresh_full_state(&com, &config, &discovery).await;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn refresh_discovery_with(&self, handle: &com_thread::ComThreadHandle) {
+        let names = handle.enumerate_sessions().await;
+        let cfg = self.config.read().await;
+        let pinned_lc: std::collections::HashSet<String> = cfg
+            .pinned_apps
+            .iter()
+            .map(|p| p.process_name.to_lowercase())
+            .collect();
+        drop(cfg);
+        let mut state = self.discovery.write().await;
+        state.observe(&names, &pinned_lc);
+        debug!(
+            "WinAudio discovery: {} active session(s), order={:?}",
+            names.len(),
+            state.discovered_order
+        );
+    }
+}
+
+/// Re-enumerate discovery so newly opened apps land in the FIFO order,
+/// then trigger master + per-session feedback emission. Used both at
+/// startup and on every "Windows Audio" page activation.
+#[cfg(target_os = "windows")]
+async fn refresh_full_state(
+    com: &Arc<RwLock<Option<com_thread::ComThreadHandle>>>,
+    config: &Arc<RwLock<WinAudioConfig>>,
+    discovery: &Arc<RwLock<mapping::DiscoveryState>>,
+) {
+    let com_guard = com.read().await;
+    let Some(handle) = com_guard.as_ref() else {
+        return;
+    };
+
+    let names = handle.enumerate_sessions().await;
+    let cfg = config.read().await;
+    let pinned_lc: std::collections::HashSet<String> = cfg
+        .pinned_apps
+        .iter()
+        .map(|p| p.process_name.to_lowercase())
+        .collect();
+    drop(cfg);
+    {
+        let mut state = discovery.write().await;
+        state.observe(&names, &pinned_lc);
+        debug!(
+            "WinAudio refresh: {} active session(s), discovery order={:?}",
+            names.len(),
+            state.discovered_order
+        );
+    }
+
+    handle.refresh_master();
+    handle.refresh_sessions();
+}
+
+/// MIDI channel (0-based) the master fader lives on, in MCU mode.
+/// Channel 9 (1-based) is the master strip, encoded as 0x08 internally.
+const MASTER_FADER_CHANNEL_0BASED: u8 = 8;
+
+/// Convert a raw fader value from the router into a `[0.0, 1.0]` scalar.
+///
+/// X-Touch fader controls produce 14-bit PitchBend (0..=16383), forwarded
+/// verbatim through `ctx.value`. A value <= 1.0 is assumed to already be
+/// normalized (e.g. from a future CC mapping wired through a transform).
+/// Anything larger is rescaled by dividing by 16383.
+fn normalize_fader_value(v: f64) -> f32 {
+    let scaled = if v > 1.0 { v / 16383.0 } else { v };
+    scaled.clamp(0.0, 1.0) as f32
+}
+
+#[cfg(test)]
+mod normalize_tests {
+    use super::normalize_fader_value;
+
+    #[test]
+    fn zero_stays_zero() {
+        assert_eq!(normalize_fader_value(0.0), 0.0);
+    }
+
+    #[test]
+    fn full_14bit_becomes_one() {
+        assert!((normalize_fader_value(16383.0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn midpoint_14bit_is_half() {
+        let mid = normalize_fader_value(8191.5);
+        assert!((mid - 0.5).abs() < 1e-3);
+    }
+
+    #[test]
+    fn already_normalized_passes_through() {
+        assert!((normalize_fader_value(0.5) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn out_of_range_clamped() {
+        assert_eq!(normalize_fader_value(99999.0), 1.0);
+        assert_eq!(normalize_fader_value(-5.0), 0.0);
+    }
+}
+
+/// Pump `AudioEvent`s emitted by the COM thread into the router's
+/// unified feedback channel as synthetic `"winaudio"` MIDI messages.
+///
+/// This lets the existing feedback pipeline (anti-echo, fader_setpoint,
+/// state actor, page-aware filtering) handle Windows audio updates the
+/// same way it handles OBS / Voicemeeter feedback — no special-casing
+/// in the router.
+///
+/// `config` and `discovery` are read on every session event to resolve
+/// process names to fader slots, so the consumer always reflects the
+/// current pinned/discovered mapping.
+#[cfg(target_os = "windows")]
+async fn run_event_consumer(
+    mut event_rx: mpsc::UnboundedReceiver<com_thread::AudioEvent>,
+    feedback_tx: mpsc::Sender<(String, Vec<u8>)>,
+    config: Arc<RwLock<WinAudioConfig>>,
+    discovery: Arc<RwLock<mapping::DiscoveryState>>,
+) {
+    debug!("WinAudio event consumer task started");
+    while let Some(event) = event_rx.recv().await {
+        match event {
+            com_thread::AudioEvent::MasterVolumeChanged { scalar, mute: _ } => {
+                let raw = build_pitchbend_raw(MASTER_FADER_CHANNEL_0BASED, scalar);
+                if feedback_tx
+                    .send((DRIVER_NAME.to_string(), raw))
+                    .await
+                    .is_err()
+                {
+                    debug!("WinAudio feedback channel closed, exiting consumer");
+                    break;
+                }
+            },
+            com_thread::AudioEvent::SessionVolumeSnapshot {
+                process_name_lc,
+                scalar,
+                mute: _,
+            } => {
+                // Resolve the fader slot this session currently occupies.
+                let cfg = config.read().await;
+                let disc = discovery.read().await;
+                let slots = mapping::compute_slots(&cfg.pinned_apps, &disc);
+                let Some(binding) = slots
+                    .iter()
+                    .find(|b| b.process_name.as_deref() == Some(process_name_lc.as_str()))
+                else {
+                    drop(disc);
+                    drop(cfg);
+                    debug!(
+                        "session snapshot for '{}' has no fader slot, ignored",
+                        process_name_lc
+                    );
+                    continue;
+                };
+                let channel0 = binding.fader.saturating_sub(1);
+                drop(disc);
+                drop(cfg);
+
+                let raw = build_pitchbend_raw(channel0, scalar);
+                if feedback_tx
+                    .send((DRIVER_NAME.to_string(), raw))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            },
+        }
+    }
+}
+
+/// Build a raw 3-byte PitchBend message for `channel0` (0-based MIDI channel).
+fn build_pitchbend_raw(channel0: u8, scalar: f32) -> Vec<u8> {
+    use crate::midi::convert::denormalize_to_14bit;
+    let value14 = denormalize_to_14bit(scalar.clamp(0.0, 1.0) as f64);
+    let lsb = (value14 & 0x7F) as u8;
+    let msb = ((value14 >> 7) & 0x7F) as u8;
+    vec![0xE0 | (channel0 & 0x0F), lsb, msb]
+}

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -25,6 +25,7 @@ use crate::drivers::{Driver, ExecutionContext};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::Value;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, info, warn};
@@ -35,19 +36,15 @@ pub use actions::{parse_session_target, SessionTarget};
 pub const DRIVER_NAME: &str = "winaudio";
 
 pub struct WinAudioDriver {
-    /// Pinned-app + (later) discovered-session configuration cloned from AppConfig.
     config: Arc<RwLock<WinAudioConfig>>,
-    /// Set by `init`, cleared by `shutdown`.
-    initialized: Arc<RwLock<bool>>,
-    /// Optional Router handle for emitting LCD updates and reading state.
+    initialized: AtomicBool,
     /// Wired post-construction via [`WinAudioDriver::set_router`].
     router: Arc<RwLock<Option<Arc<crate::router::Router>>>>,
-    /// Optional feedback channel; wired post-construction. The COM event
-    /// consumer task uses this to inject synthetic feedback messages
-    /// (`("winaudio", raw_midi)`) into the unified router feedback path.
+    /// Wired post-construction. The COM event consumer task uses this to
+    /// inject synthetic `("winaudio", raw_midi)` feedback into the unified
+    /// router feedback path.
     feedback_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<u8>)>>>>,
-    /// Stable discovery order of non-pinned process names. Updated whenever
-    /// we re-enumerate; never reorders existing entries.
+    /// Stable FIFO of non-pinned process names; never reorders existing entries.
     discovery: Arc<RwLock<mapping::DiscoveryState>>,
     #[cfg(target_os = "windows")]
     com: Arc<RwLock<Option<com_thread::ComThreadHandle>>>,
@@ -57,7 +54,7 @@ impl WinAudioDriver {
     pub fn new(config: WinAudioConfig) -> Self {
         Self {
             config: Arc::new(RwLock::new(config)),
-            initialized: Arc::new(RwLock::new(false)),
+            initialized: AtomicBool::new(false),
             router: Arc::new(RwLock::new(None)),
             feedback_tx: Arc::new(RwLock::new(None)),
             discovery: Arc::new(RwLock::new(mapping::DiscoveryState::default())),
@@ -139,12 +136,12 @@ impl Driver for WinAudioDriver {
                 },
             }
         }
-        *self.initialized.write().await = true;
+        self.initialized.store(true, Ordering::Release);
         Ok(())
     }
 
     async fn execute(&self, action: &str, params: Vec<Value>, ctx: ExecutionContext) -> Result<()> {
-        if !*self.initialized.read().await {
+        if !self.initialized.load(Ordering::Acquire) {
             warn!(
                 "WinAudio driver not initialized, dropping action '{}'",
                 action
@@ -188,7 +185,7 @@ impl Driver for WinAudioDriver {
     }
 
     async fn shutdown(&self) -> Result<()> {
-        *self.initialized.write().await = false;
+        self.initialized.store(false, Ordering::Release);
         #[cfg(target_os = "windows")]
         {
             if let Some(handle) = self.com.write().await.take() {
@@ -249,7 +246,6 @@ impl WinAudioDriver {
                 com.set_session_scalar(process_name_lc, scalar);
             }
         }
-        let _ = scalar; // silence unused warning on non-windows
         Ok(())
     }
 
@@ -379,15 +375,11 @@ async fn refresh_full_state(
 /// Channel 9 (1-based) is the master strip, encoded as 0x08 internally.
 const MASTER_FADER_CHANNEL_0BASED: u8 = 8;
 
-/// Convert a raw fader value from the router into a `[0.0, 1.0]` scalar.
-///
-/// X-Touch fader controls produce 14-bit PitchBend (0..=16383), forwarded
-/// verbatim through `ctx.value`. A value <= 1.0 is assumed to already be
-/// normalized (e.g. from a future CC mapping wired through a transform).
-/// Anything larger is rescaled by dividing by 16383.
+/// Convert a raw 14-bit PitchBend value from the router into a `[0.0, 1.0]`
+/// scalar. The router forwards `ctx.value` verbatim as the integer 14-bit
+/// reading.
 fn normalize_fader_value(v: f64) -> f32 {
-    let scaled = if v > 1.0 { v / 16383.0 } else { v };
-    scaled.clamp(0.0, 1.0) as f32
+    ((v / 16383.0) as f32).clamp(0.0, 1.0)
 }
 
 #[cfg(test)]
@@ -411,11 +403,6 @@ mod normalize_tests {
     }
 
     #[test]
-    fn already_normalized_passes_through() {
-        assert!((normalize_fader_value(0.5) - 0.5).abs() < 1e-6);
-    }
-
-    #[test]
     fn out_of_range_clamped() {
         assert_eq!(normalize_fader_value(99999.0), 1.0);
         assert_eq!(normalize_fader_value(-5.0), 0.0);
@@ -435,7 +422,7 @@ mod normalize_tests {
 /// current pinned/discovered mapping.
 #[cfg(target_os = "windows")]
 async fn run_event_consumer(
-    mut event_rx: mpsc::UnboundedReceiver<com_thread::AudioEvent>,
+    mut event_rx: mpsc::Receiver<com_thread::AudioEvent>,
     feedback_tx: mpsc::Sender<(String, Vec<u8>)>,
     config: Arc<RwLock<WinAudioConfig>>,
     discovery: Arc<RwLock<mapping::DiscoveryState>>,
@@ -444,7 +431,7 @@ async fn run_event_consumer(
     while let Some(event) = event_rx.recv().await {
         match event {
             com_thread::AudioEvent::MasterVolumeChanged { scalar, mute: _ } => {
-                let raw = build_pitchbend_raw(MASTER_FADER_CHANNEL_0BASED, scalar);
+                let raw = pitchbend_bytes(MASTER_FADER_CHANNEL_0BASED, scalar);
                 if feedback_tx
                     .send((DRIVER_NAME.to_string(), raw))
                     .await
@@ -479,7 +466,7 @@ async fn run_event_consumer(
                 drop(disc);
                 drop(cfg);
 
-                let raw = build_pitchbend_raw(channel0, scalar);
+                let raw = pitchbend_bytes(channel0, scalar);
                 if feedback_tx
                     .send((DRIVER_NAME.to_string(), raw))
                     .await
@@ -492,11 +479,10 @@ async fn run_event_consumer(
     }
 }
 
-/// Build a raw 3-byte PitchBend message for `channel0` (0-based MIDI channel).
-fn build_pitchbend_raw(channel0: u8, scalar: f32) -> Vec<u8> {
-    use crate::midi::convert::denormalize_to_14bit;
-    let value14 = denormalize_to_14bit(scalar.clamp(0.0, 1.0) as f64);
-    let lsb = (value14 & 0x7F) as u8;
-    let msb = ((value14 >> 7) & 0x7F) as u8;
-    vec![0xE0 | (channel0 & 0x0F), lsb, msb]
+fn pitchbend_bytes(channel0: u8, scalar: f32) -> Vec<u8> {
+    crate::midi::MidiMessage::PitchBend {
+        channel: channel0 & 0x0F,
+        value: crate::midi::convert::denormalize_to_14bit(scalar.clamp(0.0, 1.0) as f64),
+    }
+    .to_bytes()
 }

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -426,9 +426,18 @@ mod normalize_tests {
 /// same way it handles OBS / Voicemeeter feedback — no special-casing
 /// in the router.
 ///
-/// `config` and `discovery` are read on every session event to resolve
+/// `config` and `discovery` are read on each flush tick to resolve
 /// process names to fader slots, so the consumer always reflects the
 /// current pinned/discovered mapping.
+///
+/// **Coalescing:** the OS audio engine fires `OnSimpleVolumeChanged`
+/// once per intermediate value while the user drags the Windows mixer
+/// slider. Sending each one as a discrete fader command makes the
+/// motorized fader chase every step instead of jumping to the final
+/// position. We buffer the latest `(scalar, mute)` per channel and
+/// flush at `FLUSH_INTERVAL_MS`, which lets the motor settle on the
+/// final value while keeping perceived latency well under the
+/// 50 ms feel threshold.
 #[cfg(target_os = "windows")]
 async fn run_event_consumer(
     mut event_rx: mpsc::Receiver<com_thread::AudioEvent>,
@@ -436,52 +445,122 @@ async fn run_event_consumer(
     config: Arc<RwLock<WinAudioConfig>>,
     discovery: Arc<RwLock<mapping::DiscoveryState>>,
 ) {
+    use std::collections::HashMap;
+    use tokio::time::{interval, Duration, MissedTickBehavior};
+
+    /// Max emit rate per channel (~20 Hz). The X-Touch motorized fader
+    /// physically can't follow updates faster than this without lagging.
+    const FLUSH_INTERVAL_MS: u64 = 50;
+
     debug!("WinAudio event consumer task started");
-    while let Some(event) = event_rx.recv().await {
-        match event {
-            com_thread::AudioEvent::MasterVolumeChanged { scalar, mute } => {
-                let cfg = config.read().await;
-                let channel0 = master_fader_channel0(cfg.master_fader);
-                let mute_note = cfg.master_mute_note;
-                drop(cfg);
-                if !emit_volume_and_mute(&feedback_tx, channel0, scalar, mute_note, mute).await {
-                    debug!("WinAudio feedback channel closed, exiting consumer");
+
+    // Per-channel buffer of the latest pending feedback. Keyed by the
+    // 0-based MIDI channel of the fader; sub-channel state is the
+    // (scalar, mute_note, mute_bool) triple we'd otherwise have sent.
+    // Inserting overwrites the previous pending value — that's the
+    // coalesce.
+    let mut pending: HashMap<u8, PendingFeedback> = HashMap::new();
+
+    let mut ticker = interval(Duration::from_millis(FLUSH_INTERVAL_MS));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            biased;
+            event = event_rx.recv() => {
+                let Some(event) = event else {
+                    debug!("WinAudio event consumer: source closed");
                     break;
-                }
-            },
-            com_thread::AudioEvent::SessionVolumeSnapshot {
-                process_name_lc,
-                scalar,
-                mute,
-            } => {
-                // Resolve the fader slot this session currently occupies.
-                let cfg = config.read().await;
-                let disc = discovery.read().await;
-                let slots = mapping::compute_slots(&cfg.pinned_apps, &disc);
-                let Some(binding) = slots
-                    .iter()
-                    .find(|b| b.process_name.as_deref() == Some(process_name_lc.as_str()))
-                else {
-                    drop(disc);
-                    drop(cfg);
-                    debug!(
-                        "session snapshot for '{}' has no fader slot, ignored",
-                        process_name_lc
-                    );
-                    continue;
                 };
-                let fader = binding.fader;
+                buffer_event(&mut pending, event, &config, &discovery).await;
+            }
+            _ = ticker.tick() => {
+                if pending.is_empty() {
+                    continue;
+                }
+                for (channel0, p) in pending.drain() {
+                    if !emit_volume_and_mute(
+                        &feedback_tx, channel0, p.scalar, p.mute_note, p.mute,
+                    )
+                    .await
+                    {
+                        debug!("WinAudio feedback channel closed, exiting consumer");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct PendingFeedback {
+    scalar: f32,
+    mute_note: u8,
+    mute: bool,
+}
+
+/// Resolve an `AudioEvent` to a `(channel0, payload)` and stash it in
+/// the coalesce buffer. Out-of-mapping events (snapshots for sessions
+/// that don't have a fader slot) are dropped silently.
+#[cfg(target_os = "windows")]
+async fn buffer_event(
+    pending: &mut std::collections::HashMap<u8, PendingFeedback>,
+    event: com_thread::AudioEvent,
+    config: &Arc<RwLock<WinAudioConfig>>,
+    discovery: &Arc<RwLock<mapping::DiscoveryState>>,
+) {
+    match event {
+        com_thread::AudioEvent::MasterVolumeChanged { scalar, mute } => {
+            let cfg = config.read().await;
+            let channel0 = master_fader_channel0(cfg.master_fader);
+            let mute_note = cfg.master_mute_note;
+            drop(cfg);
+            pending.insert(
+                channel0,
+                PendingFeedback {
+                    scalar,
+                    mute_note,
+                    mute,
+                },
+            );
+        },
+        com_thread::AudioEvent::SessionVolumeSnapshot {
+            process_name_lc,
+            scalar,
+            mute,
+        } => {
+            let cfg = config.read().await;
+            let disc = discovery.read().await;
+            let slots = mapping::compute_slots(&cfg.pinned_apps, &disc);
+            let Some(binding) = slots
+                .iter()
+                .find(|b| b.process_name.as_deref() == Some(process_name_lc.as_str()))
+            else {
                 drop(disc);
                 drop(cfg);
+                debug!(
+                    "session snapshot for '{}' has no fader slot, ignored",
+                    process_name_lc
+                );
+                return;
+            };
+            let fader = binding.fader;
+            drop(disc);
+            drop(cfg);
 
-                // session<N> on strip N → fader channel N-1, mute Note N+15.
-                let channel0 = fader.saturating_sub(1);
-                let mute_note = MUTE_NOTE_BASE + fader.clamp(1, 8);
-                if !emit_volume_and_mute(&feedback_tx, channel0, scalar, mute_note, mute).await {
-                    break;
-                }
-            },
-        }
+            // session<N> on strip N → fader channel N-1, mute Note N+15.
+            let channel0 = fader.saturating_sub(1);
+            let mute_note = MUTE_NOTE_BASE + fader.clamp(1, 8);
+            pending.insert(
+                channel0,
+                PendingFeedback {
+                    scalar,
+                    mute_note,
+                    mute,
+                },
+            );
+        },
     }
 }
 

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -382,16 +382,6 @@ fn master_fader_channel0(master_fader: u8) -> u8 {
     master_fader.saturating_sub(1).min(8)
 }
 
-/// Resolve which mute button (Note number on channel 0) carries the
-/// master-mute LED. Mirrors `master_fader_channel0`: regular strips
-/// 1..=8 → mute notes 16..=23. The dedicated master strip (9) has no
-/// dedicated mute button on the X-Touch surface, so we fall back to
-/// `mute8` in that case.
-fn master_mute_note(master_fader: u8) -> u8 {
-    let strip = master_fader.clamp(1, 8);
-    MUTE_NOTE_BASE + strip
-}
-
 /// Convert a raw 14-bit PitchBend value from the router into a `[0.0, 1.0]`
 /// scalar. The router forwards `ctx.value` verbatim as the integer 14-bit
 /// reading.
@@ -448,9 +438,10 @@ async fn run_event_consumer(
     while let Some(event) = event_rx.recv().await {
         match event {
             com_thread::AudioEvent::MasterVolumeChanged { scalar, mute } => {
-                let master_fader = config.read().await.master_fader;
-                let channel0 = master_fader_channel0(master_fader);
-                let mute_note = master_mute_note(master_fader);
+                let cfg = config.read().await;
+                let channel0 = master_fader_channel0(cfg.master_fader);
+                let mute_note = cfg.master_mute_note;
+                drop(cfg);
                 if !emit_volume_and_mute(&feedback_tx, channel0, scalar, mute_note, mute).await {
                     debug!("WinAudio feedback channel closed, exiting consumer");
                     break;
@@ -522,23 +513,17 @@ async fn emit_volume_and_mute(
     true
 }
 
-/// MCU mute-LED convention: Note On (velocity 0x7F) = lit (muted), Note
-/// Off = unlit. Buttons live on MIDI channel 0.
+/// X-Touch button-LED convention: always `NoteOn`, with velocity 127 to
+/// light and velocity 0 to extinguish. The hardware treats `NoteOff` as
+/// a button-release event, not an LED-off — see `xtouch.rs::set_button_led`
+/// for the canonical comment.
 fn mute_note_bytes(note: u8, muted: bool) -> Vec<u8> {
-    let msg = if muted {
-        crate::midi::MidiMessage::NoteOn {
-            channel: 0,
-            note,
-            velocity: 0x7F,
-        }
-    } else {
-        crate::midi::MidiMessage::NoteOff {
-            channel: 0,
-            note,
-            velocity: 0,
-        }
-    };
-    msg.to_bytes()
+    crate::midi::MidiMessage::NoteOn {
+        channel: 0,
+        note,
+        velocity: if muted { 127 } else { 0 },
+    }
+    .to_bytes()
 }
 
 fn pitchbend_bytes(channel0: u8, scalar: f32) -> Vec<u8> {

--- a/src/drivers/winaudio/session.rs
+++ b/src/drivers/winaudio/session.rs
@@ -30,10 +30,14 @@ pub struct SessionInfo {
     pub process_name: String,
     /// Live `ISimpleAudioVolume` interface. Confined to the COM thread.
     pub volume: ISimpleAudioVolume,
+    /// Live session-control interface, kept so we can register
+    /// `IAudioSessionEvents` for live volume-change notifications.
+    /// Confined to the COM thread.
+    pub control: IAudioSessionControl2,
 }
 
 pub struct SessionManager {
-    manager: IAudioSessionManager2,
+    pub manager: IAudioSessionManager2,
 }
 
 impl SessionManager {
@@ -100,6 +104,7 @@ impl SessionManager {
                     pid,
                     process_name,
                     volume,
+                    control: control2,
                 });
             }
         }

--- a/src/drivers/winaudio/session.rs
+++ b/src/drivers/winaudio/session.rs
@@ -1,0 +1,164 @@
+//! Audio session enumeration and per-app volume control.
+//!
+//! Wraps `IAudioSessionManager2` / `IAudioSessionEnumerator` and resolves
+//! sessions to their owning process via `IAudioSessionControl2::GetProcessId`
+//! plus `QueryFullProcessImageNameW`. Volume changes use `ISimpleAudioVolume`
+//! (which every session control instance can be cast to).
+
+#![cfg(target_os = "windows")]
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use tracing::{debug, trace, warn};
+use windows::core::Interface;
+use windows::Win32::Foundation::{CloseHandle, BOOL, HANDLE};
+use windows::Win32::Media::Audio::{
+    eConsole, eRender, IAudioSessionControl2, IAudioSessionManager2, IMMDeviceEnumerator,
+    ISimpleAudioVolume, MMDeviceEnumerator,
+};
+use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
+use windows::Win32::System::Threading::{
+    OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT, PROCESS_QUERY_LIMITED_INFORMATION,
+};
+
+#[derive(Debug, Clone)]
+pub struct SessionInfo {
+    pub pid: u32,
+    /// Lowercase executable name (e.g. "discord.exe"). Empty if the
+    /// owning process couldn't be opened (e.g. system session, race).
+    pub process_name: String,
+    /// Live `ISimpleAudioVolume` interface. Confined to the COM thread.
+    pub volume: ISimpleAudioVolume,
+}
+
+pub struct SessionManager {
+    manager: IAudioSessionManager2,
+}
+
+impl SessionManager {
+    pub fn open() -> Result<Self> {
+        unsafe {
+            let enumerator: IMMDeviceEnumerator =
+                CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                    .context("CoCreateInstance(MMDeviceEnumerator)")?;
+            let device = enumerator
+                .GetDefaultAudioEndpoint(eRender, eConsole)
+                .context("GetDefaultAudioEndpoint(eRender, eConsole)")?;
+            let manager: IAudioSessionManager2 = device
+                .Activate(CLSCTX_ALL, None)
+                .context("Activate IAudioSessionManager2")?;
+            Ok(Self { manager })
+        }
+    }
+
+    /// Enumerate all currently active sessions on the default render endpoint.
+    /// Skips system sessions (process_id == 0) and sessions whose owning
+    /// process can no longer be opened.
+    pub fn enumerate(&self) -> Result<Vec<SessionInfo>> {
+        let mut out = Vec::new();
+        unsafe {
+            let enumerator = self
+                .manager
+                .GetSessionEnumerator()
+                .context("GetSessionEnumerator")?;
+            let count = enumerator.GetCount().context("session GetCount")?;
+            for i in 0..count {
+                let control = match enumerator.GetSession(i) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        trace!("GetSession({}) failed: {:?}", i, e);
+                        continue;
+                    },
+                };
+                let control2: IAudioSessionControl2 = match control.cast() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        trace!("cast to IAudioSessionControl2 failed: {:?}", e);
+                        continue;
+                    },
+                };
+                let pid = control2.GetProcessId().unwrap_or(0);
+                if pid == 0 {
+                    continue;
+                }
+                let volume: ISimpleAudioVolume = match control2.cast() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        trace!("cast to ISimpleAudioVolume failed: {:?}", e);
+                        continue;
+                    },
+                };
+                let process_name = process_image_name(pid)
+                    .map(|p| {
+                        p.file_name()
+                            .map(|s| s.to_string_lossy().to_lowercase())
+                            .unwrap_or_default()
+                    })
+                    .unwrap_or_default();
+                out.push(SessionInfo {
+                    pid,
+                    process_name,
+                    volume,
+                });
+            }
+        }
+        Ok(out)
+    }
+}
+
+fn process_image_name(pid: u32) -> Result<PathBuf> {
+    unsafe {
+        let handle: HANDLE = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, BOOL(0), pid)
+            .with_context(|| format!("OpenProcess({pid})"))?;
+        if handle.is_invalid() {
+            anyhow::bail!("OpenProcess({pid}) returned invalid handle");
+        }
+        let mut buffer = [0u16; 1024];
+        let mut size = buffer.len() as u32;
+        let result = QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_FORMAT(0),
+            windows::core::PWSTR(buffer.as_mut_ptr()),
+            &mut size,
+        );
+        let _ = CloseHandle(handle);
+        result.with_context(|| format!("QueryFullProcessImageNameW({pid})"))?;
+        let name = String::from_utf16_lossy(&buffer[..size as usize]);
+        Ok(PathBuf::from(name))
+    }
+}
+
+/// Set scalar volume (0.0..=1.0) on a session interface.
+pub fn set_session_volume(session: &SessionInfo, scalar: f32) -> Result<()> {
+    unsafe {
+        session
+            .volume
+            .SetMasterVolume(scalar.clamp(0.0, 1.0), std::ptr::null())
+            .context("ISimpleAudioVolume::SetMasterVolume")?;
+    }
+    Ok(())
+}
+
+/// Toggle mute on a session.
+pub fn toggle_session_mute(session: &SessionInfo) -> Result<()> {
+    unsafe {
+        let cur = session.volume.GetMute().context("GetMute")?;
+        session
+            .volume
+            .SetMute(!cur.as_bool(), std::ptr::null())
+            .context("SetMute")?;
+        debug!(
+            "Toggled mute for pid={} ({}) -> {}",
+            session.pid,
+            session.process_name,
+            !cur.as_bool()
+        );
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn warn_skipped(reason: &str) {
+    warn!("session enumeration skipped: {}", reason);
+}

--- a/src/drivers/winaudio/session.rs
+++ b/src/drivers/winaudio/session.rs
@@ -10,7 +10,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 use windows::core::Interface;
 use windows::Win32::Foundation::{CloseHandle, BOOL, HANDLE};
 use windows::Win32::Media::Audio::{
@@ -156,9 +156,4 @@ pub fn toggle_session_mute(session: &SessionInfo) -> Result<()> {
         );
     }
     Ok(())
-}
-
-#[allow(dead_code)]
-fn warn_skipped(reason: &str) {
-    warn!("session enumeration skipped: {}", reason);
 }

--- a/src/drivers/winaudio/session_events.rs
+++ b/src/drivers/winaudio/session_events.rs
@@ -1,0 +1,135 @@
+//! Per-session COM callbacks: `IAudioSessionEvents` for live volume/mute
+//! change notifications, and `IAudioSessionNotification` for catching
+//! sessions that appear after driver startup (e.g. an app that starts
+//! producing audio later).
+//!
+//! Both callbacks fire on a WASAPI-internal thread, so the bodies must
+//! be non-blocking. They communicate back to the COM thread by pushing
+//! events / commands through `mpsc` channels (`try_send`, drop on full).
+
+#![cfg(target_os = "windows")]
+
+use tokio::sync::mpsc;
+use tracing::trace;
+
+use windows::core::{implement, GUID};
+use windows::Win32::Foundation::BOOL;
+use windows::Win32::Media::Audio::{
+    AudioSessionDisconnectReason, AudioSessionState, IAudioSessionControl,
+    IAudioSessionEvents_Impl, IAudioSessionNotification_Impl,
+};
+
+use super::com_thread::{AudioCmd, AudioEvent};
+
+/// Listener attached to one `IAudioSessionControl` to relay volume/mute
+/// changes back to the gateway as `SessionVolumeSnapshot` events.
+#[implement(windows::Win32::Media::Audio::IAudioSessionEvents)]
+pub struct SessionEventsCallback {
+    event_tx: mpsc::Sender<AudioEvent>,
+    process_name_lc: String,
+}
+
+impl SessionEventsCallback {
+    pub fn new(event_tx: mpsc::Sender<AudioEvent>, process_name_lc: String) -> Self {
+        Self {
+            event_tx,
+            process_name_lc,
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+impl IAudioSessionEvents_Impl for SessionEventsCallback {
+    fn OnDisplayNameChanged(
+        &self,
+        _new_display_name: &windows::core::PCWSTR,
+        _event_context: *const GUID,
+    ) -> windows::core::Result<()> {
+        Ok(())
+    }
+
+    fn OnIconPathChanged(
+        &self,
+        _new_icon_path: &windows::core::PCWSTR,
+        _event_context: *const GUID,
+    ) -> windows::core::Result<()> {
+        Ok(())
+    }
+
+    fn OnSimpleVolumeChanged(
+        &self,
+        new_volume: f32,
+        new_mute: BOOL,
+        _event_context: *const GUID,
+    ) -> windows::core::Result<()> {
+        let scalar = new_volume.clamp(0.0, 1.0);
+        let mute = new_mute.as_bool();
+        trace!(
+            "SessionEvents OnSimpleVolumeChanged: {} v={:.3} m={}",
+            self.process_name_lc,
+            scalar,
+            mute
+        );
+        let _ = self.event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
+            process_name_lc: self.process_name_lc.clone(),
+            scalar,
+            mute,
+        });
+        Ok(())
+    }
+
+    fn OnChannelVolumeChanged(
+        &self,
+        _channel_count: u32,
+        _new_channel_volume_array: *const f32,
+        _changed_channel: u32,
+        _event_context: *const GUID,
+    ) -> windows::core::Result<()> {
+        Ok(())
+    }
+
+    fn OnGroupingParamChanged(
+        &self,
+        _new_grouping_param: *const GUID,
+        _event_context: *const GUID,
+    ) -> windows::core::Result<()> {
+        Ok(())
+    }
+
+    fn OnStateChanged(&self, _state: AudioSessionState) -> windows::core::Result<()> {
+        Ok(())
+    }
+
+    fn OnSessionDisconnected(
+        &self,
+        _disconnect_reason: AudioSessionDisconnectReason,
+    ) -> windows::core::Result<()> {
+        Ok(())
+    }
+}
+
+/// Listener attached to the session manager. When a new session is
+/// created on the default render endpoint, request a session refresh
+/// so the COM thread can register `IAudioSessionEvents` on it.
+#[implement(windows::Win32::Media::Audio::IAudioSessionNotification)]
+pub struct NewSessionCallback {
+    cmd_tx: mpsc::Sender<AudioCmd>,
+}
+
+impl NewSessionCallback {
+    pub fn new(cmd_tx: mpsc::Sender<AudioCmd>) -> Self {
+        Self { cmd_tx }
+    }
+}
+
+#[allow(non_snake_case)]
+impl IAudioSessionNotification_Impl for NewSessionCallback {
+    fn OnSessionCreated(
+        &self,
+        _new_session: Option<&IAudioSessionControl>,
+    ) -> windows::core::Result<()> {
+        trace!("IAudioSessionNotification: new session created");
+        let _ = self.cmd_tx.try_send(AudioCmd::RefreshSessions);
+        Ok(())
+    }
+}

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -13,8 +13,10 @@ mod driver;
 mod feedback;
 mod indicators;
 mod page;
+mod page_availability;
 mod refresh;
 mod refresh_plan;
+pub mod voicemeeter_detector;
 mod xtouch_input;
 
 pub use crate::event_bus::{LiveEvent, LiveEventTx};
@@ -69,6 +71,9 @@ pub struct Router {
     /// the main event loop to flush pending MIDI / display updates. The
     /// X-Touch input arm does this inline after `on_midi_from_xtouch`.
     pub display_refresh_notify: Arc<tokio::sync::Notify>,
+    /// Per-page availability filter, driven by Voicemeeter presence.
+    /// Always `Some` after construction; rebuilt on config reload.
+    pub(crate) page_availability: Arc<RwLock<page_availability::PageAvailability>>,
 }
 
 impl Router {
@@ -96,6 +101,17 @@ impl Router {
         })?;
         let camera_targets = Arc::new(CameraTargetState::new(camera_db));
 
+        let page_availability = page_availability::PageAvailability::new(
+            config
+                .pages
+                .iter()
+                .map(|p| page_availability::PageFlags {
+                    requires_voicemeeter: p.requires_voicemeeter,
+                    auto_when_voicemeeter_absent: p.auto_when_voicemeeter_absent,
+                })
+                .collect(),
+        );
+
         Ok(Self {
             config: Arc::new(RwLock::new(config)),
             drivers: Arc::new(RwLock::new(HashMap::new())),
@@ -111,6 +127,7 @@ impl Router {
             camera_targets,
             live_tx: Arc::new(tokio::sync::RwLock::new(None)),
             display_refresh_notify: Arc::new(tokio::sync::Notify::new()),
+            page_availability: Arc::new(RwLock::new(page_availability)),
         })
     }
 
@@ -171,6 +188,87 @@ impl Router {
     /// Take pending MIDI messages (consumes them, leaving empty Vec)
     pub async fn take_pending_midi(&self) -> Vec<Vec<u8>> {
         std::mem::take(&mut *self.pending_midi_messages.lock().await)
+    }
+
+    /// Subscribe to a Voicemeeter detector and drive page availability +
+    /// auto-switch in response to VM state transitions.
+    ///
+    /// Spawns a background task that lives for as long as the detector
+    /// publishes events. Safe to call once at startup.
+    pub fn spawn_voicemeeter_watcher(
+        self: &Arc<Self>,
+        mut state_rx: tokio::sync::watch::Receiver<Option<voicemeeter_detector::VmState>>,
+    ) {
+        let router = self.clone();
+        tokio::spawn(async move {
+            // Track the previous state so we can decide on auto-switch
+            // direction. `None` until the detector publishes its first
+            // state.
+            let mut prev: Option<voicemeeter_detector::VmState> = None;
+            loop {
+                if state_rx.changed().await.is_err() {
+                    break;
+                }
+                let new = *state_rx.borrow();
+                let Some(new_state) = new else {
+                    continue;
+                };
+                let current_index = *router.active_page_index.read().await;
+                let target = {
+                    let mut availability = router.page_availability.write().await;
+                    availability.set_vm_state(Some(new_state));
+                    availability.auto_switch_target(current_index, prev, new_state)
+                };
+                prev = Some(new_state);
+
+                if let Some(target_idx) = target {
+                    if target_idx == current_index {
+                        continue;
+                    }
+                    let target_str = target_idx.to_string();
+                    if let Err(e) = router.set_active_page(&target_str).await {
+                        tracing::warn!("VM auto-switch to page {} failed: {}", target_idx, e);
+                    } else {
+                        tracing::info!(
+                            "VM state {:?} -> auto-switched to page index {}",
+                            new_state,
+                            target_idx
+                        );
+                    }
+                } else {
+                    // No auto-switch needed, but we still want to refresh
+                    // the page since locked pages may now be available
+                    // (or vice versa) — the LED indicators / control
+                    // mappings on the current page don't change, only
+                    // navigation does, so this is a no-op for now.
+                }
+            }
+        });
+    }
+
+    /// Push a dynamic LCD label update for one X-Touch strip.
+    ///
+    /// `channel` is 1-based (1..=8). `upper` and `lower` are the two LCD
+    /// lines (truncated/padded to 7 ASCII chars by the SysEx builder).
+    ///
+    /// The two SysEx messages produced are appended to `pending_midi_messages`
+    /// and `display_refresh_notify` is signalled so the main loop flushes
+    /// them to the X-Touch on its next pass.
+    pub async fn push_lcd_label(&self, channel: u8, upper: &str, lower: &str) {
+        if !(1..=8).contains(&channel) {
+            tracing::warn!("push_lcd_label: invalid channel {} (1..=8)", channel);
+            return;
+        }
+        let strip_index = channel - 1;
+        let (upper_msg, lower_msg) =
+            crate::xtouch::build_lcd_strip_sysex(strip_index, upper, lower);
+
+        let mut buf = self.pending_midi_messages.lock().await;
+        buf.push(upper_msg);
+        buf.push(lower_msg);
+        drop(buf);
+
+        self.display_refresh_notify.notify_one();
     }
 
     /// Get current timestamp in milliseconds
@@ -271,6 +369,23 @@ impl Router {
 
         // Update config
         *self.config.write().await = new_config;
+
+        // Rebuild page availability filter from the new page metadata.
+        {
+            let config = self.config.read().await;
+            let new_flags: Vec<page_availability::PageFlags> = config
+                .pages
+                .iter()
+                .map(|p| page_availability::PageFlags {
+                    requires_voicemeeter: p.requires_voicemeeter,
+                    auto_when_voicemeeter_absent: p.auto_when_voicemeeter_absent,
+                })
+                .collect();
+            let mut availability = self.page_availability.write().await;
+            let prev_state = availability.current_vm_state();
+            *availability = page_availability::PageAvailability::new(new_flags);
+            availability.set_vm_state(prev_state);
+        }
 
         // Ensure active page index is still valid
         let config = self.config.read().await;

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -221,26 +221,21 @@ impl Router {
                 };
                 prev = Some(new_state);
 
-                if let Some(target_idx) = target {
-                    if target_idx == current_index {
-                        continue;
-                    }
-                    let target_str = target_idx.to_string();
-                    if let Err(e) = router.set_active_page(&target_str).await {
-                        tracing::warn!("VM auto-switch to page {} failed: {}", target_idx, e);
-                    } else {
-                        tracing::info!(
-                            "VM state {:?} -> auto-switched to page index {}",
-                            new_state,
-                            target_idx
-                        );
-                    }
+                let Some(target_idx) = target else {
+                    continue;
+                };
+                if target_idx == current_index {
+                    continue;
+                }
+                let target_str = target_idx.to_string();
+                if let Err(e) = router.set_active_page(&target_str).await {
+                    tracing::warn!("VM auto-switch to page {} failed: {}", target_idx, e);
                 } else {
-                    // No auto-switch needed, but we still want to refresh
-                    // the page since locked pages may now be available
-                    // (or vice versa) — the LED indicators / control
-                    // mappings on the current page don't change, only
-                    // navigation does, so this is a no-op for now.
+                    tracing::info!(
+                        "VM state {:?} -> auto-switched to page index {}",
+                        new_state,
+                        target_idx
+                    );
                 }
             }
         });

--- a/src/router/page.rs
+++ b/src/router/page.rs
@@ -100,40 +100,51 @@ impl super::Router {
         Err(anyhow!("Page '{}' not found", name_or_index))
     }
 
-    /// Navigate to the next page (circular)
+    /// Navigate to the next available page.
+    ///
+    /// Pages tagged `requires_voicemeeter: true` are skipped while VM is
+    /// absent. If no other available page exists, the call is a no-op.
     pub async fn next_page(&self) {
         let config = self.config.read().await;
         if config.pages.is_empty() {
             return;
         }
 
+        let availability = self.page_availability.read().await;
         let mut index = self.active_page_index.write().await;
-        *index = (*index + 1) % config.pages.len();
+        let Some(target) = availability.next_available(*index) else {
+            tracing::debug!("next_page: no other available page (VM absent locking nav)");
+            return;
+        };
+        *index = target;
         let page_name = config.pages[*index].name.clone();
         info!("Next page → {}", page_name);
         drop(index);
+        drop(availability);
         drop(config);
 
         self.refresh_page().await;
         self.emit_page_changed().await;
     }
 
-    /// Navigate to the previous page (circular)
+    /// Navigate to the previous available page (skips locked pages).
     pub async fn prev_page(&self) {
         let config = self.config.read().await;
         if config.pages.is_empty() {
             return;
         }
 
+        let availability = self.page_availability.read().await;
         let mut index = self.active_page_index.write().await;
-        *index = if *index == 0 {
-            config.pages.len() - 1
-        } else {
-            *index - 1
+        let Some(target) = availability.prev_available(*index) else {
+            tracing::debug!("prev_page: no other available page (VM absent locking nav)");
+            return;
         };
+        *index = target;
         let page_name = config.pages[*index].name.clone();
         info!("Previous page → {}", page_name);
         drop(index);
+        drop(availability);
         drop(config);
 
         self.refresh_page().await;

--- a/src/router/page_availability.rs
+++ b/src/router/page_availability.rs
@@ -1,0 +1,237 @@
+//! Page availability filter based on Voicemeeter presence.
+//!
+//! Tracks which pages are currently navigable through prev/next based on
+//! Voicemeeter presence and provides skip-aware navigation helpers.
+
+use crate::router::voicemeeter_detector::VmState;
+
+#[derive(Debug, Clone)]
+pub struct PageAvailability {
+    /// Per-page metadata: (requires_voicemeeter, auto_when_voicemeeter_absent).
+    flags: Vec<PageFlags>,
+    /// Last observed VM state. `None` means no detector active — all pages
+    /// are considered available.
+    vm_state: Option<VmState>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PageFlags {
+    pub requires_voicemeeter: bool,
+    pub auto_when_voicemeeter_absent: bool,
+}
+
+impl PageAvailability {
+    pub fn new(flags: Vec<PageFlags>) -> Self {
+        Self {
+            flags,
+            vm_state: None,
+        }
+    }
+
+    pub fn set_vm_state(&mut self, state: Option<VmState>) {
+        self.vm_state = state;
+    }
+
+    pub fn current_vm_state(&self) -> Option<VmState> {
+        self.vm_state
+    }
+
+    pub fn page_count(&self) -> usize {
+        self.flags.len()
+    }
+
+    pub fn is_available(&self, index: usize) -> bool {
+        let Some(flags) = self.flags.get(index) else {
+            return false;
+        };
+
+        match self.vm_state {
+            // No detector configured — every page is available.
+            None => true,
+            Some(VmState::Running) => true,
+            Some(VmState::Absent) => !flags.requires_voicemeeter,
+        }
+    }
+
+    pub fn next_available(&self, current: usize) -> Option<usize> {
+        if self.flags.is_empty() {
+            return None;
+        }
+        let n = self.flags.len();
+        for offset in 1..=n {
+            let idx = (current + offset) % n;
+            if idx == current {
+                continue;
+            }
+            if self.is_available(idx) {
+                return Some(idx);
+            }
+        }
+        None
+    }
+
+    pub fn prev_available(&self, current: usize) -> Option<usize> {
+        if self.flags.is_empty() {
+            return None;
+        }
+        let n = self.flags.len();
+        for offset in 1..=n {
+            let idx = (current + n - (offset % n)) % n;
+            if idx == current {
+                continue;
+            }
+            if self.is_available(idx) {
+                return Some(idx);
+            }
+        }
+        None
+    }
+
+    /// Compute the page index to switch to when the VM state transitions.
+    ///
+    /// - `Running -> Absent`: returns the index of the page tagged
+    ///   `auto_when_voicemeeter_absent`, if any.
+    /// - `Absent -> Running`: returns the first page with
+    ///   `requires_voicemeeter` set, if the user is currently on the
+    ///   "absent" page (i.e. the auto-switch target). This avoids yanking the
+    ///   user away from a non-VM page (e.g. a lighting page) they've manually
+    ///   navigated to.
+    pub fn auto_switch_target(
+        &self,
+        current_index: usize,
+        prev: Option<VmState>,
+        new: VmState,
+    ) -> Option<usize> {
+        match (prev, new) {
+            (Some(VmState::Absent) | None, VmState::Running) => {
+                let on_absent_page = self
+                    .flags
+                    .get(current_index)
+                    .map(|f| f.auto_when_voicemeeter_absent)
+                    .unwrap_or(false);
+                if !on_absent_page {
+                    return None;
+                }
+                self.flags.iter().position(|f| f.requires_voicemeeter)
+            },
+            (Some(VmState::Running) | None, VmState::Absent) => self
+                .flags
+                .iter()
+                .position(|f| f.auto_when_voicemeeter_absent),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flags(requires: bool, auto_absent: bool) -> PageFlags {
+        PageFlags {
+            requires_voicemeeter: requires,
+            auto_when_voicemeeter_absent: auto_absent,
+        }
+    }
+
+    fn build(pages: Vec<(bool, bool)>) -> PageAvailability {
+        PageAvailability::new(pages.into_iter().map(|(r, a)| flags(r, a)).collect())
+    }
+
+    #[test]
+    fn all_available_when_no_state() {
+        let pa = build(vec![(true, false), (false, false), (false, true)]);
+        assert!(pa.is_available(0));
+        assert!(pa.is_available(1));
+        assert!(pa.is_available(2));
+    }
+
+    #[test]
+    fn vm_running_keeps_all_available() {
+        let mut pa = build(vec![(true, false), (false, false), (false, true)]);
+        pa.set_vm_state(Some(VmState::Running));
+        assert!(pa.is_available(0));
+        assert!(pa.is_available(1));
+        assert!(pa.is_available(2));
+    }
+
+    #[test]
+    fn vm_absent_locks_required_pages() {
+        let mut pa = build(vec![(true, false), (false, false), (false, true)]);
+        pa.set_vm_state(Some(VmState::Absent));
+        assert!(!pa.is_available(0));
+        assert!(pa.is_available(1));
+        assert!(pa.is_available(2));
+    }
+
+    #[test]
+    fn next_skips_locked_pages() {
+        let mut pa = build(vec![
+            (true, false),
+            (true, false),
+            (false, false),
+            (false, true),
+        ]);
+        pa.set_vm_state(Some(VmState::Absent));
+        assert_eq!(pa.next_available(2), Some(3));
+        assert_eq!(pa.next_available(3), Some(2));
+    }
+
+    #[test]
+    fn prev_skips_locked_pages() {
+        let mut pa = build(vec![
+            (true, false),
+            (false, false),
+            (true, false),
+            (false, true),
+        ]);
+        pa.set_vm_state(Some(VmState::Absent));
+        assert_eq!(pa.prev_available(3), Some(1));
+        assert_eq!(pa.prev_available(1), Some(3));
+    }
+
+    #[test]
+    fn next_returns_none_when_no_alternative() {
+        let mut pa = build(vec![(true, false), (false, true)]);
+        pa.set_vm_state(Some(VmState::Absent));
+        // From the only available page, next must return None or self.
+        // We never return self (the "current" index is excluded).
+        assert_eq!(pa.next_available(1), None);
+    }
+
+    #[test]
+    fn auto_switch_running_to_absent_targets_absent_page() {
+        let pa = build(vec![(true, false), (false, false), (false, true)]);
+        assert_eq!(
+            pa.auto_switch_target(0, Some(VmState::Running), VmState::Absent),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn auto_switch_absent_to_running_targets_required_page_if_on_absent_page() {
+        let pa = build(vec![(true, false), (false, false), (false, true)]);
+        // User is on the "auto-when-absent" page (index 2). VM comes back -> jump to required page.
+        assert_eq!(
+            pa.auto_switch_target(2, Some(VmState::Absent), VmState::Running),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn auto_switch_absent_to_running_no_op_if_user_navigated_away() {
+        let pa = build(vec![(true, false), (false, false), (false, true)]);
+        // User is on a free page (index 1) — don't yank them back.
+        assert_eq!(
+            pa.auto_switch_target(1, Some(VmState::Absent), VmState::Running),
+            None
+        );
+    }
+
+    #[test]
+    fn auto_switch_initial_absent_targets_absent_page() {
+        let pa = build(vec![(true, false), (false, false), (false, true)]);
+        // At startup, prev is None.
+        assert_eq!(pa.auto_switch_target(0, None, VmState::Absent), Some(2));
+    }
+}

--- a/src/router/page_availability.rs
+++ b/src/router/page_availability.rs
@@ -20,6 +20,12 @@ pub struct PageFlags {
     pub auto_when_voicemeeter_absent: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum Direction {
+    Forward,
+    Backward,
+}
+
 impl PageAvailability {
     pub fn new(flags: Vec<PageFlags>) -> Self {
         Self {
@@ -54,37 +60,24 @@ impl PageAvailability {
     }
 
     pub fn next_available(&self, current: usize) -> Option<usize> {
-        if self.flags.is_empty() {
-            return None;
-        }
-        let n = self.flags.len();
-        for offset in 1..=n {
-            let idx = (current + offset) % n;
-            if idx == current {
-                continue;
-            }
-            if self.is_available(idx) {
-                return Some(idx);
-            }
-        }
-        None
+        self.find_available(current, Direction::Forward)
     }
 
     pub fn prev_available(&self, current: usize) -> Option<usize> {
-        if self.flags.is_empty() {
+        self.find_available(current, Direction::Backward)
+    }
+
+    fn find_available(&self, current: usize, dir: Direction) -> Option<usize> {
+        let n = self.flags.len();
+        if n == 0 {
             return None;
         }
-        let n = self.flags.len();
-        for offset in 1..=n {
-            let idx = (current + n - (offset % n)) % n;
-            if idx == current {
-                continue;
-            }
-            if self.is_available(idx) {
-                return Some(idx);
-            }
-        }
-        None
+        (1..=n)
+            .map(|offset| match dir {
+                Direction::Forward => (current + offset) % n,
+                Direction::Backward => (current + n - (offset % n)) % n,
+            })
+            .find(|&idx| idx != current && self.is_available(idx))
     }
 
     /// Compute the page index to switch to when the VM state transitions.

--- a/src/router/tests.rs
+++ b/src/router/tests.rs
@@ -29,6 +29,8 @@ fn make_test_config(pages: Vec<PageConfig>) -> AppConfig {
         paging: None,
         gamepad: None,
         pages_global: None,
+        voicemeeter_detection: None,
+        winaudio: None,
         pages,
         tray: None,
     }
@@ -37,10 +39,7 @@ fn make_test_config(pages: Vec<PageConfig>) -> AppConfig {
 fn make_test_page(name: &str) -> PageConfig {
     PageConfig {
         name: name.to_string(),
-        controls: None,
-        lcd: None,
-        passthrough: None,
-        passthroughs: None,
+        ..PageConfig::default()
     }
 }
 

--- a/src/router/voicemeeter_detector.rs
+++ b/src/router/voicemeeter_detector.rs
@@ -1,0 +1,226 @@
+//! Voicemeeter presence detector.
+//!
+//! Polls Win32 ToolHelp32Snapshot every `poll_interval` and broadcasts
+//! transitions between [`VmState::Running`] and [`VmState::Absent`].
+//!
+//! The detector publishes its state through a `tokio::sync::watch` channel so
+//! late subscribers always observe the latest known state without blocking.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tracing::info;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmState {
+    Running,
+    Absent,
+}
+
+pub trait ProcessScanner: Send + Sync + 'static {
+    fn any_running(&self, names_lowercase: &[String]) -> bool;
+}
+
+pub struct VmDetector {
+    state_rx: watch::Receiver<Option<VmState>>,
+    _task: JoinHandle<()>,
+}
+
+impl VmDetector {
+    pub fn spawn(
+        scanner: Arc<dyn ProcessScanner>,
+        process_names: Vec<String>,
+        poll_interval: Duration,
+    ) -> Self {
+        let (state_tx, state_rx) = watch::channel(None);
+        let names_lc: Vec<String> = process_names.iter().map(|s| s.to_lowercase()).collect();
+
+        let task = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(poll_interval);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+
+                let names = names_lc.clone();
+                let scanner = scanner.clone();
+                let running = tokio::task::spawn_blocking(move || scanner.any_running(&names))
+                    .await
+                    .unwrap_or(false);
+                let new_state = if running {
+                    VmState::Running
+                } else {
+                    VmState::Absent
+                };
+
+                let prev = *state_tx.borrow();
+                if prev != Some(new_state) {
+                    info!(
+                        "Voicemeeter state transition: {:?} -> {:?}",
+                        prev, new_state
+                    );
+                    if state_tx.send(Some(new_state)).is_err() {
+                        // No more receivers — exit detector loop.
+                        return;
+                    }
+                }
+            }
+        });
+
+        Self {
+            state_rx,
+            _task: task,
+        }
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<Option<VmState>> {
+        self.state_rx.clone()
+    }
+
+    pub fn current(&self) -> Option<VmState> {
+        *self.state_rx.borrow()
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub struct Win32ProcessScanner;
+
+#[cfg(target_os = "windows")]
+impl ProcessScanner for Win32ProcessScanner {
+    fn any_running(&self, names_lowercase: &[String]) -> bool {
+        windows_impl::any_process_matches(names_lowercase)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub struct NoopProcessScanner;
+
+#[cfg(not(target_os = "windows"))]
+impl ProcessScanner for NoopProcessScanner {
+    fn any_running(&self, _: &[String]) -> bool {
+        false
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use tracing::warn;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+
+    pub fn any_process_matches(names_lc: &[String]) -> bool {
+        unsafe {
+            let snapshot = match CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) {
+                Ok(h) => h,
+                Err(e) => {
+                    warn!("CreateToolhelp32Snapshot failed: {e}");
+                    return false;
+                },
+            };
+
+            let mut entry = PROCESSENTRY32W {
+                dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+                ..Default::default()
+            };
+
+            let mut found = false;
+            if Process32FirstW(snapshot, &mut entry).is_ok() {
+                loop {
+                    let exe_name = wchar_to_string(&entry.szExeFile).to_lowercase();
+                    if names_lc.iter().any(|n| n == &exe_name) {
+                        found = true;
+                        break;
+                    }
+                    if Process32NextW(snapshot, &mut entry).is_err() {
+                        break;
+                    }
+                }
+            }
+
+            let _ = CloseHandle(snapshot);
+            found
+        }
+    }
+
+    fn wchar_to_string(wchars: &[u16]) -> String {
+        let len = wchars.iter().position(|&c| c == 0).unwrap_or(wchars.len());
+        String::from_utf16_lossy(&wchars[..len])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct MockScanner {
+        running: AtomicBool,
+    }
+
+    impl ProcessScanner for MockScanner {
+        fn any_running(&self, _: &[String]) -> bool {
+            self.running.load(Ordering::Acquire)
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn initial_state_is_published() {
+        let scanner = Arc::new(MockScanner {
+            running: AtomicBool::new(true),
+        });
+        let detector = VmDetector::spawn(
+            scanner,
+            vec!["voicemeeter.exe".into()],
+            Duration::from_millis(10),
+        );
+
+        let mut rx = detector.subscribe();
+        // Wait for initial publication.
+        rx.changed().await.unwrap();
+        assert_eq!(*rx.borrow(), Some(VmState::Running));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn detects_running_to_absent() {
+        let scanner = Arc::new(MockScanner {
+            running: AtomicBool::new(true),
+        });
+        let detector = VmDetector::spawn(
+            scanner.clone(),
+            vec!["voicemeeter.exe".into()],
+            Duration::from_millis(10),
+        );
+
+        let mut rx = detector.subscribe();
+        rx.changed().await.unwrap();
+        assert_eq!(*rx.borrow(), Some(VmState::Running));
+
+        scanner.running.store(false, Ordering::Release);
+        rx.changed().await.unwrap();
+        assert_eq!(*rx.borrow(), Some(VmState::Absent));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn detects_absent_to_running() {
+        let scanner = Arc::new(MockScanner {
+            running: AtomicBool::new(false),
+        });
+        let detector = VmDetector::spawn(
+            scanner.clone(),
+            vec!["voicemeeter.exe".into()],
+            Duration::from_millis(10),
+        );
+
+        let mut rx = detector.subscribe();
+        rx.changed().await.unwrap();
+        assert_eq!(*rx.borrow(), Some(VmState::Absent));
+
+        scanner.running.store(true, Ordering::Release);
+        rx.changed().await.unwrap();
+        assert_eq!(*rx.borrow(), Some(VmState::Running));
+    }
+}

--- a/src/router/voicemeeter_detector.rs
+++ b/src/router/voicemeeter_detector.rs
@@ -35,7 +35,11 @@ impl VmDetector {
         poll_interval: Duration,
     ) -> Self {
         let (state_tx, state_rx) = watch::channel(None);
-        let names_lc: Vec<String> = process_names.iter().map(|s| s.to_lowercase()).collect();
+        let names_lc: Arc<[String]> = process_names
+            .iter()
+            .map(|s| s.to_lowercase())
+            .collect::<Vec<_>>()
+            .into();
 
         let task = tokio::spawn(async move {
             let mut interval = tokio::time::interval(poll_interval);

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -123,6 +123,7 @@ pub enum AppKey {
     Voicemeeter,
     Qlc,
     Obs,
+    WinAudio,
     #[serde(rename = "midi-bridge")]
     MidiBridge,
 }
@@ -134,6 +135,7 @@ impl AppKey {
             AppKey::Voicemeeter,
             AppKey::Qlc,
             AppKey::Obs,
+            AppKey::WinAudio,
             AppKey::MidiBridge,
         ]
     }
@@ -144,6 +146,7 @@ impl AppKey {
             "voicemeeter" => Some(AppKey::Voicemeeter),
             "qlc" => Some(AppKey::Qlc),
             "obs" => Some(AppKey::Obs),
+            "winaudio" => Some(AppKey::WinAudio),
             "midi-bridge" => Some(AppKey::MidiBridge),
             _ => None,
         }
@@ -155,6 +158,7 @@ impl AppKey {
             AppKey::Voicemeeter => "voicemeeter",
             AppKey::Qlc => "qlc",
             AppKey::Obs => "obs",
+            AppKey::WinAudio => "winaudio",
             AppKey::MidiBridge => "midi-bridge",
         }
     }

--- a/src/xtouch.rs
+++ b/src/xtouch.rs
@@ -398,59 +398,10 @@ impl XTouchDriver {
             bail!("Invalid LCD strip index: {} (must be 0-7)", strip_index);
         }
 
-        // Convert text to 7-byte ASCII arrays
-        let upper_bytes = Self::ascii7(upper, 7);
-        let lower_bytes = Self::ascii7(lower, 7);
-
-        // SysEx header for X-Touch LCD
-        let header = vec![0x00, 0x00, 0x66, 0x14, 0x12];
-
-        // Position for upper line (0x00 + strip * 7)
-        let pos_top = strip_index * 7;
-
-        // Position for lower line (0x38 + strip * 7)
-        let pos_bot = 0x38 + strip_index * 7;
-
-        // Send upper line
-        let mut upper_data = header.clone();
-        upper_data.push(pos_top);
-        upper_data.extend_from_slice(&upper_bytes);
-        self.send(&MidiMessage::SysEx { data: upper_data }).await?;
-
-        // Send lower line
-        let mut lower_data = header;
-        lower_data.push(pos_bot);
-        lower_data.extend_from_slice(&lower_bytes);
-        self.send(&MidiMessage::SysEx { data: lower_data }).await?;
-
+        let (upper_msg, lower_msg) = build_lcd_strip_sysex(strip_index, upper, lower);
+        self.send_raw(&upper_msg).await?;
+        self.send_raw(&lower_msg).await?;
         Ok(())
-    }
-
-    /// Convert text to 7-bit ASCII array with specific length
-    fn ascii7(text: &str, length: usize) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(length);
-
-        for (i, ch) in text.chars().enumerate() {
-            if i >= length {
-                break;
-            }
-
-            // Only printable ASCII (0x20-0x7E), otherwise space
-            let code = ch as u32;
-            let byte = if (0x20..=0x7E).contains(&code) {
-                code as u8
-            } else {
-                0x20 // Space
-            };
-            bytes.push(byte);
-        }
-
-        // Pad with spaces to reach desired length
-        while bytes.len() < length {
-            bytes.push(0x20);
-        }
-
-        bytes
     }
 
     /// Send only lower line LCD text (for value overlay)
@@ -459,7 +410,7 @@ impl XTouchDriver {
             bail!("Invalid LCD strip index: {} (must be 0-7)", strip_index);
         }
 
-        let lower_bytes = Self::ascii7(lower, 7);
+        let lower_bytes = ascii7(lower, 7);
 
         let header = vec![0x00, 0x00, 0x66, 0x14, 0x12];
         let pos_bot = 0x38 + strip_index * 7;
@@ -671,6 +622,58 @@ impl XTouchDriver {
         debug!("X-Touch hardware reset complete");
         Ok(())
     }
+}
+
+/// Convert text to a fixed-length 7-bit ASCII byte slice (printable only,
+/// non-printable replaced with 0x20, padded with spaces).
+pub(crate) fn ascii7(text: &str, length: usize) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(length);
+    for (i, ch) in text.chars().enumerate() {
+        if i >= length {
+            break;
+        }
+        let code = ch as u32;
+        let byte = if (0x20..=0x7E).contains(&code) {
+            code as u8
+        } else {
+            0x20
+        };
+        bytes.push(byte);
+    }
+    while bytes.len() < length {
+        bytes.push(0x20);
+    }
+    bytes
+}
+
+/// Build the two SysEx messages required to update one LCD strip
+/// (upper line + lower line) on an X-Touch.
+///
+/// `strip_index` must be 0..=7. Returns `(upper_sysex, lower_sysex)` as
+/// raw MIDI byte sequences ready for `xtouch.send_raw()` or queueing
+/// into the router's pending-MIDI buffer.
+pub fn build_lcd_strip_sysex(strip_index: u8, upper: &str, lower: &str) -> (Vec<u8>, Vec<u8>) {
+    debug_assert!(strip_index <= 7);
+    let upper_bytes = ascii7(upper, 7);
+    let lower_bytes = ascii7(lower, 7);
+
+    let pos_top = strip_index * 7;
+    let pos_bot = 0x38 + strip_index * 7;
+
+    // SysEx framing: F0 00 00 66 14 12 <pos> <7 bytes ASCII> F7
+    let mut upper_msg = Vec::with_capacity(15);
+    upper_msg.extend_from_slice(&[0xF0, 0x00, 0x00, 0x66, 0x14, 0x12]);
+    upper_msg.push(pos_top);
+    upper_msg.extend_from_slice(&upper_bytes);
+    upper_msg.push(0xF7);
+
+    let mut lower_msg = Vec::with_capacity(15);
+    lower_msg.extend_from_slice(&[0xF0, 0x00, 0x00, 0x66, 0x14, 0x12]);
+    lower_msg.push(pos_bot);
+    lower_msg.extend_from_slice(&lower_bytes);
+    lower_msg.push(0xF7);
+
+    (upper_msg, lower_msg)
 }
 
 /// Port discovery utilities


### PR DESCRIPTION
## Summary

Adds a Windows Core Audio driver (master + per-app session volume/mute) and a Voicemeeter presence detector that auto-switches to a fallback page when Voicemeeter is absent.

- **winaudio driver** (\`src/drivers/winaudio/\`): dedicated COM (STA) thread for \`IAudioEndpointVolume\` + \`IAudioSessionManager2\`; pinned and discovered fader slots; bidirectional sync via \`IAudioEndpointVolumeCallback\`
- **Voicemeeter detector** (\`src/router/voicemeeter_detector.rs\`): polls Win32 ToolHelp every 5s, broadcasts state via \`watch\` channel
- **Page availability** (\`src/router/page_availability.rs\`): per-page \`requires_voicemeeter\` / \`auto_when_voicemeeter_absent\` flags; prev/next nav skips locked pages
- **Config schema** extended with \`voicemeeter_detection\` and \`winaudio\` sections
- **LCD SysEx builder** extracted from xtouch.rs for runtime use by the new driver

## Follow-ups

Filed during PR-review simplification pass:
- #35 perf: cache audio session enumeration (priority: high — re-enumerates per fader move)
- #36 replace 800ms post-init sleep with watcher-based trigger
- #37 refactor: split run_com_loop into per-arm helpers
- #38 validate winaudio session-target params at config load
- #39 page watcher hardcodes \"Windows Audio\" display name
- #40 perf: cache pinned_lc HashSet across hot-path resolves
- #41 bug: duplicate feedback emits after master volume/mute set

## Test plan

- [x] X-Touch master fader moves Windows volume; Win+Vol+/- moves the motorized fader back
- [x] Pinned app (e.g. Discord in YAML) holds its slot whether or not it's making sound
- [ ] Discovered apps appear in stable FIFO order in remaining slots
- [ ] Mute button toggles per-session mute; LED reflects external mute changes
- [ ] Voicemeeter killed -> auto-switches to fallback page; relaunched -> returns to VM page if user is on the fallback
- [ ] Prev/next page navigation skips Voicemeeter-required pages while VM absent
- [ ] Non-Windows build compiles (driver is a no-op stub)
- [ ] \`cargo test --lib\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)