### PR TITLE
refactor(gamepad+obs): dedup helpers, reuse emit_signal, change-detection guard

### DIFF
--- a/src/drivers/obs/actions.rs
+++ b/src/drivers/obs/actions.rs
@@ -11,10 +11,10 @@ use async_trait::async_trait;
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
-use super::camera_actions::extract_gamepad_slot;
 use super::driver::ObsDriver;
 use super::ptz_actions::PtzAxis;
 use super::{Driver, ExecutionContext, IndicatorCallback};
+use crate::input::gamepad::extract_gamepad_slot;
 
 impl ObsDriver {
     /// Resolve camera_id to (scene, source) from camera_control config.
@@ -368,7 +368,7 @@ impl Driver for ObsDriver {
 
                 // Update modifier state in camera_targets
                 if let Some(ref camera_targets) = ctx.camera_targets {
-                    camera_targets.set_ptz_modifier(&slot, pressed);
+                    camera_targets.set_ptz_modifier(slot, pressed);
                     debug!(
                         "PTZ modifier: {} = {} (control: {})",
                         slot, pressed, control_id

--- a/src/drivers/obs/camera_actions.rs
+++ b/src/drivers/obs/camera_actions.rs
@@ -4,20 +4,12 @@
 
 use anyhow::{Context, Result};
 use serde_json::Value;
-use tracing::{debug, info};
+use tracing::info;
 
 use super::camera::ViewMode;
 use super::driver::ObsDriver;
 use super::ExecutionContext;
-
-/// Extract gamepad slot from control_id (e.g., "gamepad1" from "gamepad1.btn.a")
-pub(super) fn extract_gamepad_slot(control_id: &str) -> String {
-    control_id
-        .split('.')
-        .next()
-        .unwrap_or("gamepad1")
-        .to_string()
-}
+use crate::input::gamepad::{extract_gamepad_slot, DEFAULT_GAMEPAD_SLOT, GAMEPAD_PREFIX};
 
 /// Context for setting PTZ target from gamepad controls
 pub(super) struct PtzTargetContext<'a> {
@@ -37,7 +29,7 @@ impl<'a> PtzTargetContext<'a> {
     /// Check if this is a gamepad control
     pub(super) fn is_gamepad(&self) -> bool {
         self.control_id
-            .map(|id| id.starts_with("gamepad"))
+            .map(|id| id.starts_with(GAMEPAD_PREFIX))
             .unwrap_or(false)
     }
 
@@ -45,7 +37,8 @@ impl<'a> PtzTargetContext<'a> {
     pub(super) fn gamepad_slot(&self) -> String {
         self.control_id
             .map(extract_gamepad_slot)
-            .unwrap_or_else(|| "gamepad1".to_string())
+            .unwrap_or(DEFAULT_GAMEPAD_SLOT)
+            .to_string()
     }
 
     /// Set PTZ target for gamepad if applicable. Returns true if target was set.

--- a/src/drivers/obs/connection.rs
+++ b/src/drivers/obs/connection.rs
@@ -134,37 +134,14 @@ impl ObsDriver {
         Ok(())
     }
 
-    /// Spawn background task to listen to OBS events
+    /// Spawn background task to listen to OBS events.
+    ///
+    /// Hands the listener a cheap `clone_for_task` of the driver so it can
+    /// reuse [`ObsDriver::emit_signal`] and access shared state (caches,
+    /// scene cells, shutdown flag) without re-passing every Arc field.
     pub(super) fn spawn_event_listener(&self) {
-        let client = Arc::clone(&self.client);
-        let studio_mode = Arc::clone(&self.studio_mode);
-        let program_scene = Arc::clone(&self.program_scene);
-        let preview_scene = Arc::clone(&self.preview_scene);
-        let emitters = Arc::clone(&self.indicator_emitters);
-        let last_selected = Arc::clone(&self.last_selected_sent);
-        let shutdown_flag = Arc::clone(&self.shutdown_flag);
-        let activity_tracker = Arc::clone(&self.activity_tracker);
-        let camera_control_config = Arc::clone(&self.camera_control_config);
-        let camera_control_state = Arc::clone(&self.camera_control_state);
-        let transform_cache = Arc::clone(&self.transform_cache);
-        let item_id_cache = Arc::clone(&self.item_id_cache);
-        let driver_for_reconnect = self.clone_for_task();
-
-        tokio::spawn(super::event_listener::run_event_listener(
-            client,
-            studio_mode,
-            program_scene,
-            preview_scene,
-            emitters,
-            last_selected,
-            shutdown_flag,
-            activity_tracker,
-            camera_control_config,
-            camera_control_state,
-            transform_cache,
-            item_id_cache,
-            driver_for_reconnect,
-        ));
+        let driver = self.clone_for_task();
+        tokio::spawn(super::event_listener::run_event_listener(driver));
     }
 
     /// Static helper to emit selectedScene with debouncing

--- a/src/drivers/obs/connection.rs
+++ b/src/drivers/obs/connection.rs
@@ -280,19 +280,33 @@ impl ObsDriver {
         }
     }
 
-    /// Emit all indicator signals (studio mode, program/preview/selected scenes)
+    /// Emit `value` for `signal` and update the [`Self::last_emitted`]
+    /// dedupe cache so the event-listener's change-detection guard stays
+    /// consistent with what indicator subscribers have seen.
+    fn emit_signal_tracked(&self, signal: &'static str, value: Value) {
+        self.last_emitted.write().insert(signal, value.clone());
+        self.emit_signal(signal, value);
+    }
+
+    /// Emit all indicator signals (studio mode, program/preview/selected scenes).
+    ///
+    /// Called from `refresh_state` on both initial connect and reconnect.
+    /// Updates the `last_emitted` dedupe cache for every signal so the next
+    /// real OBS event with a value different from the post-reconnect state
+    /// (but equal to a value cached pre-reconnect) is not silently dropped
+    /// by [`emit_and_debounce`]'s change-detection guard.
     pub(super) async fn emit_all_signals(&self) {
         let studio_mode = *self.studio_mode.read();
         let program_scene = self.program_scene.read().clone();
         let preview_scene = self.preview_scene.read().clone();
 
-        // Emit individual signals
-        self.emit_signal(super::signals::STUDIO_MODE, Value::Bool(studio_mode));
-        self.emit_signal(
+        // Emit individual signals (tracked so post-reconnect dedupe stays sane).
+        self.emit_signal_tracked(super::signals::STUDIO_MODE, Value::Bool(studio_mode));
+        self.emit_signal_tracked(
             super::signals::CURRENT_PROGRAM_SCENE,
             Value::String(program_scene.clone()),
         );
-        self.emit_signal(
+        self.emit_signal_tracked(
             super::signals::CURRENT_PREVIEW_SCENE,
             Value::String(preview_scene.clone()),
         );
@@ -307,7 +321,7 @@ impl ObsDriver {
         // Only emit if changed (deduplication)
         let mut last = self.last_selected_sent.write();
         if last.as_ref() != Some(&selected) {
-            self.emit_signal(
+            self.emit_signal_tracked(
                 super::signals::SELECTED_SCENE,
                 Value::String(selected.clone()),
             );

--- a/src/drivers/obs/driver.rs
+++ b/src/drivers/obs/driver.rs
@@ -38,6 +38,11 @@ pub struct ObsDriver {
     // Indicator emission (using parking_lot for sync access)
     pub(super) indicator_emitters: Arc<parking_lot::RwLock<Vec<super::IndicatorCallback>>>,
     pub(super) last_selected_sent: Arc<parking_lot::RwLock<Option<String>>>,
+    /// Last value emitted per signal, keyed by `&'static` signal name (e.g.
+    /// `signals::CURRENT_PROGRAM_SCENE`). Used by `emit_and_debounce` as a
+    /// change-detection guard so identical scene/studio events don't allocate
+    /// or re-fan-out downstream.
+    pub(super) last_emitted: Arc<parking_lot::RwLock<HashMap<&'static str, serde_json::Value>>>,
 
     // Connection status tracking
     pub(super) status_callbacks: Arc<parking_lot::RwLock<Vec<crate::tray::StatusCallback>>>,
@@ -98,6 +103,7 @@ impl ObsDriver {
             item_id_cache: Arc::new(parking_lot::RwLock::new(HashMap::new())),
             indicator_emitters: Arc::new(parking_lot::RwLock::new(Vec::new())),
             last_selected_sent: Arc::new(parking_lot::RwLock::new(None)),
+            last_emitted: Arc::new(parking_lot::RwLock::new(HashMap::new())),
             status_callbacks: Arc::new(parking_lot::RwLock::new(Vec::new())),
             current_status: Arc::new(parking_lot::RwLock::new(
                 crate::tray::ConnectionStatus::Disconnected,
@@ -187,6 +193,7 @@ impl ObsDriver {
             item_id_cache: Arc::clone(&self.item_id_cache),
             indicator_emitters: Arc::clone(&self.indicator_emitters),
             last_selected_sent: Arc::clone(&self.last_selected_sent),
+            last_emitted: Arc::clone(&self.last_emitted),
             status_callbacks: Arc::clone(&self.status_callbacks),
             current_status: Arc::clone(&self.current_status),
             activity_tracker: Arc::clone(&self.activity_tracker),

--- a/src/drivers/obs/event_listener.rs
+++ b/src/drivers/obs/event_listener.rs
@@ -110,7 +110,20 @@ fn sync_view_mode(
 /// Emit a signal via the driver and schedule the debounced `selectedScene`
 /// follow-up. Reuses [`ObsDriver::emit_signal`] so we have a single emission
 /// path for all indicator subscribers.
-fn emit_and_debounce(driver: &ObsDriver, signal: &str, value: Value) {
+///
+/// Skips the entire emission + debounce pipeline when `value` matches the
+/// last value emitted for `signal` (change-detection guard, #31). This
+/// eliminates redundant `String::clone` allocations and Tokio task spawns
+/// during continuous OBS scene-switching when the same scene is reasserted.
+fn emit_and_debounce(driver: &ObsDriver, signal: &'static str, value: Value) {
+    {
+        let last = driver.last_emitted.read();
+        if last.get(signal) == Some(&value) {
+            return;
+        }
+    }
+    driver.last_emitted.write().insert(signal, value.clone());
+
     driver.emit_signal(signal, value);
 
     ObsDriver::emit_selected_debounced(

--- a/src/drivers/obs/event_listener.rs
+++ b/src/drivers/obs/event_listener.rs
@@ -107,57 +107,37 @@ fn sync_view_mode(
     }
 }
 
-/// Emit a signal to all indicator emitters and schedule debounced selectedScene
-fn emit_and_debounce(
-    signal: &str,
-    value: Value,
-    studio_mode: &parking_lot::RwLock<bool>,
-    program_scene: &parking_lot::RwLock<String>,
-    preview_scene: &parking_lot::RwLock<String>,
-    emitters: &Arc<parking_lot::RwLock<Vec<super::IndicatorCallback>>>,
-    last_selected: &Arc<parking_lot::RwLock<Option<String>>>,
-) {
-    let emitters_guard = emitters.read();
-    for emit in emitters_guard.iter() {
-        emit(signal.to_string(), value.clone());
-    }
-    drop(emitters_guard);
+/// Emit a signal via the driver and schedule the debounced `selectedScene`
+/// follow-up. Reuses [`ObsDriver::emit_signal`] so we have a single emission
+/// path for all indicator subscribers.
+fn emit_and_debounce(driver: &ObsDriver, signal: &str, value: Value) {
+    driver.emit_signal(signal, value);
 
     ObsDriver::emit_selected_debounced(
-        *studio_mode.read(),
-        program_scene.read().clone(),
-        preview_scene.read().clone(),
-        Arc::clone(emitters),
-        Arc::clone(last_selected),
+        *driver.studio_mode.read(),
+        driver.program_scene.read().clone(),
+        driver.preview_scene.read().clone(),
+        Arc::clone(&driver.indicator_emitters),
+        Arc::clone(&driver.last_selected_sent),
     );
 }
 
-/// Run the OBS event listener loop (spawned as a tokio task)
-#[allow(clippy::too_many_arguments)]
-pub(super) async fn run_event_listener(
-    client: Arc<tokio::sync::RwLock<Option<obws::Client>>>,
-    studio_mode: Arc<parking_lot::RwLock<bool>>,
-    program_scene: Arc<parking_lot::RwLock<String>>,
-    preview_scene: Arc<parking_lot::RwLock<String>>,
-    emitters: Arc<parking_lot::RwLock<Vec<super::IndicatorCallback>>>,
-    last_selected: Arc<parking_lot::RwLock<Option<String>>>,
-    shutdown_flag: Arc<parking_lot::Mutex<bool>>,
-    activity_tracker: Arc<parking_lot::RwLock<Option<Arc<crate::tray::ActivityTracker>>>>,
-    camera_control_config: Arc<parking_lot::RwLock<Option<crate::config::CameraControlConfig>>>,
-    camera_control_state: Arc<parking_lot::RwLock<super::camera::CameraControlState>>,
-    transform_cache: Arc<parking_lot::RwLock<HashMap<String, ObsItemState>>>,
-    item_id_cache: Arc<parking_lot::RwLock<HashMap<String, i64>>>,
-    driver_for_reconnect: ObsDriver,
-) {
+/// Run the OBS event listener loop (spawned as a tokio task).
+///
+/// Takes the full [`ObsDriver`] (cheap to clone — every field is `Arc`-backed
+/// via `clone_for_task`) so that scene/studio-mode events can route through
+/// the driver's own [`ObsDriver::emit_signal`] instead of re-implementing the
+/// emission loop with a stack of `Arc<RwLock<…>>` parameters.
+pub(super) async fn run_event_listener(driver: ObsDriver) {
     loop {
-        if *shutdown_flag.lock() {
+        if *driver.shutdown_flag.lock() {
             debug!("OBS event listener shutting down");
             break;
         }
 
         // Get event stream
         let events = {
-            let guard = client.read().await;
+            let guard = driver.client.read().await;
             match guard.as_ref() {
                 Some(c) => match c.events() {
                     Ok(stream) => stream,
@@ -180,91 +160,100 @@ pub(super) async fn run_event_listener(
 
         tokio::pin!(events);
         while let Some(event) = events.next().await {
-            if *shutdown_flag.lock() {
+            if *driver.shutdown_flag.lock() {
                 break;
             }
 
-            if let Some(ref tracker) = *activity_tracker.read() {
+            if let Some(ref tracker) = *driver.activity_tracker.read() {
                 tracker.record("obs", crate::tray::ActivityDirection::Inbound);
             }
 
             match event {
                 Event::CurrentProgramSceneChanged { name } => {
                     debug!("OBS program scene changed: {}", name);
-                    *program_scene.write() = name.clone();
+                    *driver.program_scene.write() = name.clone();
 
-                    if !*studio_mode.read() {
-                        sync_view_mode(&name, &camera_control_config, &camera_control_state);
+                    if !*driver.studio_mode.read() {
+                        sync_view_mode(
+                            &name,
+                            &driver.camera_control_config,
+                            &driver.camera_control_state,
+                        );
                     }
 
                     emit_and_debounce(
+                        &driver,
                         super::signals::CURRENT_PROGRAM_SCENE,
                         Value::String(name),
-                        &studio_mode,
-                        &program_scene,
-                        &preview_scene,
-                        &emitters,
-                        &last_selected,
                     );
                 },
 
                 Event::StudioModeStateChanged { enabled } => {
                     debug!("OBS studio mode changed: {}", enabled);
-                    *studio_mode.write() = enabled;
+                    *driver.studio_mode.write() = enabled;
 
                     let active_scene = if enabled {
-                        preview_scene.read().clone()
+                        driver.preview_scene.read().clone()
                     } else {
-                        program_scene.read().clone()
+                        driver.program_scene.read().clone()
                     };
-                    sync_view_mode(&active_scene, &camera_control_config, &camera_control_state);
-
-                    emit_and_debounce(
-                        super::signals::STUDIO_MODE,
-                        Value::Bool(enabled),
-                        &studio_mode,
-                        &program_scene,
-                        &preview_scene,
-                        &emitters,
-                        &last_selected,
+                    sync_view_mode(
+                        &active_scene,
+                        &driver.camera_control_config,
+                        &driver.camera_control_state,
                     );
+
+                    emit_and_debounce(&driver, super::signals::STUDIO_MODE, Value::Bool(enabled));
                 },
 
                 Event::CurrentPreviewSceneChanged { name } => {
                     debug!("OBS preview scene changed: {}", name);
-                    *preview_scene.write() = name.clone();
+                    *driver.preview_scene.write() = name.clone();
 
-                    if *studio_mode.read() {
-                        sync_view_mode(&name, &camera_control_config, &camera_control_state);
+                    if *driver.studio_mode.read() {
+                        sync_view_mode(
+                            &name,
+                            &driver.camera_control_config,
+                            &driver.camera_control_state,
+                        );
                     }
 
                     emit_and_debounce(
+                        &driver,
                         super::signals::CURRENT_PREVIEW_SCENE,
                         Value::String(name),
-                        &studio_mode,
-                        &program_scene,
-                        &preview_scene,
-                        &emitters,
-                        &last_selected,
                     );
                 },
 
                 Event::SceneItemRemoved { scene, source, .. } => {
-                    purge_caches_for_item(&transform_cache, &item_id_cache, &scene, &source);
+                    purge_caches_for_item(
+                        &driver.transform_cache,
+                        &driver.item_id_cache,
+                        &scene,
+                        &source,
+                    );
                 },
 
                 Event::SceneRemoved { name, .. } => {
                     let prefix = format!("{}::", name);
-                    purge_caches_where(&transform_cache, &item_id_cache, "scene", &name, |k| {
-                        k.starts_with(&prefix)
-                    });
+                    purge_caches_where(
+                        &driver.transform_cache,
+                        &driver.item_id_cache,
+                        "scene",
+                        &name,
+                        |k| k.starts_with(&prefix),
+                    );
                 },
 
                 Event::InputRemoved { name } => {
                     let suffix = format!("::{}", name);
-                    purge_caches_where(&transform_cache, &item_id_cache, "source", &name, |k| {
-                        k.ends_with(&suffix)
-                    });
+                    purge_caches_where(
+                        &driver.transform_cache,
+                        &driver.item_id_cache,
+                        "source",
+                        &name,
+                        |k| k.ends_with(&suffix),
+                    );
                 },
 
                 _ => {},
@@ -274,9 +263,9 @@ pub(super) async fn run_event_listener(
         // Stream ended (disconnected)
         warn!("OBS event stream closed");
 
-        driver_for_reconnect.emit_status(crate::tray::ConnectionStatus::Disconnected);
+        driver.emit_status(crate::tray::ConnectionStatus::Disconnected);
 
-        let driver_clone = driver_for_reconnect.clone_for_task();
+        let driver_clone = driver.clone_for_task();
         tokio::spawn(async move {
             driver_clone.schedule_reconnect().await;
         });

--- a/src/input/gamepad/buttons.rs
+++ b/src/input/gamepad/buttons.rs
@@ -133,12 +133,14 @@ mod tests {
 
     #[test]
     fn test_control_id_generation() {
+        use crate::input::gamepad::DEFAULT_GAMEPAD_SLOT;
+
         assert_eq!(
-            gilrs_button_to_control_id(Button::East, "gamepad1"),
+            gilrs_button_to_control_id(Button::East, DEFAULT_GAMEPAD_SLOT),
             Some("gamepad1.btn.a".to_string())
         );
         assert_eq!(
-            gilrs_button_to_control_id(Button::DPadUp, "gamepad1"),
+            gilrs_button_to_control_id(Button::DPadUp, DEFAULT_GAMEPAD_SLOT),
             Some("gamepad1.dpad.up".to_string())
         );
     }

--- a/src/input/gamepad/hybrid_provider/gilrs_events.rs
+++ b/src/input/gamepad/hybrid_provider/gilrs_events.rs
@@ -11,6 +11,7 @@ use crate::input::gamepad::hybrid_id::HybridControllerId;
 use crate::input::gamepad::hybrid_provider::GamepadEvent;
 use crate::input::gamepad::normalize::normalize_gilrs_stick;
 use crate::input::gamepad::stick_buffer::{StickBuffer, StickId};
+use crate::input::gamepad::GAMEPAD_PREFIX;
 
 impl HybridProviderState {
     /// Poll gilrs events (non-blocking)
@@ -25,7 +26,7 @@ impl HybridProviderState {
                     continue;
                 }
             } else {
-                ("gamepad".to_string(), None)
+                (GAMEPAD_PREFIX.to_string(), None)
             };
 
             for gamepad_event in self.convert_gilrs_event(id, event, &prefix, analog_config) {

--- a/src/input/gamepad/hybrid_provider/xinput.rs
+++ b/src/input/gamepad/hybrid_provider/xinput.rs
@@ -9,6 +9,7 @@ use crate::input::gamepad::hybrid_provider::GamepadEvent;
 use crate::input::gamepad::xinput_convert::{
     convert_xinput_axes, convert_xinput_buttons, poll_xinput_controller, CachedXInputState,
 };
+use crate::input::gamepad::GAMEPAD_PREFIX;
 
 impl HybridProviderState {
     /// Poll XInput events for all 4 possible controllers
@@ -75,7 +76,7 @@ impl HybridProviderState {
                 }
             }
         } else {
-            ("gamepad".to_string(), None)
+            (GAMEPAD_PREFIX.to_string(), None)
         };
 
         // Generate button events

--- a/src/input/gamepad/mod.rs
+++ b/src/input/gamepad/mod.rs
@@ -4,6 +4,37 @@
 //! and router integration. Supports both XInput controllers (Xbox) and non-XInput
 //! controllers (FaceOff, etc.) simultaneously.
 
+/// Default gamepad slot identifier used when a control_id has no slot prefix
+/// or the slot index is unknown. All single-gamepad / legacy paths resolve to
+/// this slot.
+pub const DEFAULT_GAMEPAD_SLOT: &str = "gamepad1";
+
+/// Prefix used for every gamepad control_id (e.g. `"gamepad1.btn.a"`). Slot
+/// identifiers are always `"{GAMEPAD_PREFIX}{n}"` where `n >= 1`.
+pub const GAMEPAD_PREFIX: &str = "gamepad";
+
+/// Extract the gamepad slot prefix from a control_id.
+///
+/// For a control_id like `"gamepad1.axis.lx"` this returns `"gamepad1"`. For
+/// inputs that do not start with [`GAMEPAD_PREFIX`] (e.g. an empty string,
+/// `"foo.bar"`), this still returns the first dot-separated segment without
+/// validating it — callers that need to discriminate gamepad vs non-gamepad
+/// controls should test `result.starts_with(GAMEPAD_PREFIX)` after.
+///
+/// Returns [`DEFAULT_GAMEPAD_SLOT`] when the control_id has no first segment
+/// (empty input or starts with `'.'`).
+///
+/// This helper is allocation-free: it returns a borrow into `control_id`
+/// (except for the static fallback).
+pub fn extract_gamepad_slot(control_id: &str) -> &str {
+    let first = control_id.split('.').next().unwrap_or(DEFAULT_GAMEPAD_SLOT);
+    if first.is_empty() {
+        DEFAULT_GAMEPAD_SLOT
+    } else {
+        first
+    }
+}
+
 pub mod analog;
 pub mod axis;
 pub mod buttons;
@@ -81,4 +112,37 @@ pub async fn init(config: &GamepadConfig, router: Arc<Router>) -> Result<Option<
     debug!("Gamepad input initialized");
 
     Ok(Some(mapper))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_slot_with_full_control_id() {
+        assert_eq!(extract_gamepad_slot("gamepad1.axis.lx"), "gamepad1");
+        assert_eq!(extract_gamepad_slot("gamepad2.btn.a"), "gamepad2");
+    }
+
+    #[test]
+    fn extract_slot_with_bare_slot() {
+        assert_eq!(extract_gamepad_slot("gamepad2"), "gamepad2");
+    }
+
+    #[test]
+    fn extract_slot_empty_returns_default() {
+        assert_eq!(extract_gamepad_slot(""), DEFAULT_GAMEPAD_SLOT);
+    }
+
+    #[test]
+    fn extract_slot_non_gamepad_returns_first_segment() {
+        // Helper does not validate gamepad-ness; callers must test
+        // starts_with(GAMEPAD_PREFIX) themselves if they need to.
+        assert_eq!(extract_gamepad_slot("foo.bar"), "foo");
+    }
+
+    #[test]
+    fn constants_are_consistent() {
+        assert!(DEFAULT_GAMEPAD_SLOT.starts_with(GAMEPAD_PREFIX));
+    }
 }

--- a/src/input/gamepad/slot.rs
+++ b/src/input/gamepad/slot.rs
@@ -7,6 +7,7 @@
 //! - Per-slot analog configuration
 
 use super::hybrid_id::HybridControllerId;
+use super::GAMEPAD_PREFIX;
 use crate::config::AnalogConfig;
 use gilrs::Gilrs;
 use std::time::Instant;
@@ -61,7 +62,7 @@ impl GamepadSlot {
 
     /// Get control ID prefix for this slot (e.g., "gamepad1", "gamepad2")
     pub fn control_id_prefix(&self) -> String {
-        format!("gamepad{}", self.slot_index + 1)
+        format!("{}{}", GAMEPAD_PREFIX, self.slot_index + 1)
     }
 
     /// Connect a gamepad to this slot

--- a/src/input/gamepad/xinput_convert.rs
+++ b/src/input/gamepad/xinput_convert.rs
@@ -210,8 +210,9 @@ mod tests {
 
     #[test]
     fn test_button_conversion() {
+        use crate::input::gamepad::DEFAULT_GAMEPAD_SLOT;
         // Press A button
-        let events = convert_xinput_buttons(None, button_flags::A, "gamepad1");
+        let events = convert_xinput_buttons(None, button_flags::A, DEFAULT_GAMEPAD_SLOT);
         assert_eq!(events.len(), 1);
         match &events[0] {
             GamepadEvent::Button {
@@ -227,15 +228,18 @@ mod tests {
 
     #[test]
     fn test_button_no_change() {
+        use crate::input::gamepad::DEFAULT_GAMEPAD_SLOT;
         // Same state, no events
-        let events = convert_xinput_buttons(Some(button_flags::A), button_flags::A, "gamepad1");
+        let events =
+            convert_xinput_buttons(Some(button_flags::A), button_flags::A, DEFAULT_GAMEPAD_SLOT);
         assert_eq!(events.len(), 0);
     }
 
     #[test]
     fn test_dpad_format() {
+        use crate::input::gamepad::DEFAULT_GAMEPAD_SLOT;
         // D-Pad uses different format
-        let events = convert_xinput_buttons(None, button_flags::DPAD_UP, "gamepad1");
+        let events = convert_xinput_buttons(None, button_flags::DPAD_UP, DEFAULT_GAMEPAD_SLOT);
         assert_eq!(events.len(), 1);
         match &events[0] {
             GamepadEvent::Button { control_id, .. } => {

--- a/src/obs_indicators.rs
+++ b/src/obs_indicators.rs
@@ -208,13 +208,14 @@ fn handle_preview_scene_change(
 fn find_dynamic_gamepad_slot_from_config(
     gamepad: &Option<crate::config::GamepadConfig>,
 ) -> Option<String> {
+    use crate::input::gamepad::GAMEPAD_PREFIX;
     gamepad
         .as_ref()
         .and_then(|g| g.gamepads.as_ref())
         .and_then(|slots| {
             slots.iter().enumerate().find_map(|(i, slot)| {
                 if slot.camera_target.as_deref() == Some("dynamic") {
-                    Some(format!("gamepad{}", i + 1))
+                    Some(format!("{}{}", GAMEPAD_PREFIX, i + 1))
                 } else {
                     None
                 }

--- a/src/router/camera_target.rs
+++ b/src/router/camera_target.rs
@@ -158,6 +158,7 @@ impl CameraTargetState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::gamepad::DEFAULT_GAMEPAD_SLOT;
     use tempfile::tempdir;
 
     #[test]
@@ -166,8 +167,11 @@ mod tests {
         let db = sled::open(temp.path().join("test.sled")).unwrap();
         let state = CameraTargetState::new(db);
 
-        state.set_target("gamepad1", "Main").unwrap();
-        assert_eq!(state.get_target("gamepad1"), Some("Main".to_string()));
+        state.set_target(DEFAULT_GAMEPAD_SLOT, "Main").unwrap();
+        assert_eq!(
+            state.get_target(DEFAULT_GAMEPAD_SLOT),
+            Some("Main".to_string())
+        );
         assert_eq!(state.get_target("gamepad2"), None);
     }
 
@@ -180,14 +184,17 @@ mod tests {
         {
             let db = sled::open(&db_path).unwrap();
             let state = CameraTargetState::new(db);
-            state.set_target("gamepad1", "Jardin").unwrap();
+            state.set_target(DEFAULT_GAMEPAD_SLOT, "Jardin").unwrap();
         }
 
         // Second instance - should restore target
         {
             let db = sled::open(&db_path).unwrap();
             let state = CameraTargetState::new(db);
-            assert_eq!(state.get_target("gamepad1"), Some("Jardin".to_string()));
+            assert_eq!(
+                state.get_target(DEFAULT_GAMEPAD_SLOT),
+                Some("Jardin".to_string())
+            );
         }
     }
 
@@ -197,10 +204,10 @@ mod tests {
         let db = sled::open(temp.path().join("test.sled")).unwrap();
         let state = CameraTargetState::new(db);
 
-        state.set_target("gamepad1", "Main").unwrap();
-        assert!(state.get_target("gamepad1").is_some());
+        state.set_target(DEFAULT_GAMEPAD_SLOT, "Main").unwrap();
+        assert!(state.get_target(DEFAULT_GAMEPAD_SLOT).is_some());
 
-        state.clear_target("gamepad1").unwrap();
-        assert!(state.get_target("gamepad1").is_none());
+        state.clear_target(DEFAULT_GAMEPAD_SLOT).unwrap();
+        assert!(state.get_target(DEFAULT_GAMEPAD_SLOT).is_none());
     }
 }

--- a/src/router/driver.rs
+++ b/src/router/driver.rs
@@ -1,6 +1,7 @@
 //! Driver registration and lifecycle management
 
 use crate::drivers::{Driver, ExecutionContext};
+use crate::input::gamepad::{extract_gamepad_slot, GAMEPAD_PREFIX};
 use anyhow::{anyhow, Result};
 use serde_json::Value;
 use std::sync::Arc;
@@ -254,13 +255,16 @@ impl super::Router {
             return Ok(raw_params);
         }
 
-        // Extract gamepad slot from control_id (e.g., "gamepad1" from "gamepad1.axis.lx")
-        let gamepad_slot = control_id.split('.').next().unwrap_or("");
-
-        if !gamepad_slot.starts_with("gamepad") {
-            // Not a gamepad control, return unchanged
+        // Discriminate gamepad vs non-gamepad controls by inspecting the raw
+        // control_id. We can't use `extract_gamepad_slot` for the check
+        // because its non-gamepad fallback returns `DEFAULT_GAMEPAD_SLOT`
+        // (which always starts with `GAMEPAD_PREFIX`), masking the original
+        // intent. Once we've confirmed gamepad-ness, the helper is safe to
+        // use for the slot prefix.
+        if !control_id.starts_with(GAMEPAD_PREFIX) {
             return Ok(raw_params);
         }
+        let gamepad_slot = extract_gamepad_slot(control_id);
 
         let config = self.config.read().await;
 
@@ -272,7 +276,7 @@ impl super::Router {
             .and_then(|slots| {
                 // Determine slot index from gamepad_slot (gamepad1 -> index 0, gamepad2 -> index 1)
                 let slot_num: usize = gamepad_slot
-                    .strip_prefix("gamepad")
+                    .strip_prefix(GAMEPAD_PREFIX)
                     .and_then(|n| n.parse().ok())
                     .unwrap_or(1);
                 slots.get(slot_num.saturating_sub(1))


### PR DESCRIPTION
## Summary
- Closes #28: extract `DEFAULT_GAMEPAD_SLOT` and `GAMEPAD_PREFIX` constants in `input/gamepad/mod.rs`; replace ~20 literals across drivers, router, providers, and tests.
- Closes #26: unify `extract_gamepad_slot(&str) -> &str` (allocation-free) in `input/gamepad/mod.rs`; remove the duplicate copy in `obs/camera_actions.rs` and the inline `.split('.').next().unwrap_or("")` in `router/driver.rs`.
- Closes #27: `run_event_listener` now takes a single `ObsDriver` (cheap `clone_for_task` clone — every field is Arc-backed) instead of 13 individual `Arc<RwLock<T>>` parameters; `emit_and_debounce` calls `driver.emit_signal` directly.
- Closes #31: change-detection guard added to `emit_and_debounce` — identical scene/studio events short-circuit before any `String::clone` or task spawn. Backed by a new `last_emitted: Arc<RwLock<HashMap<&'static str, Value>>>` field on `ObsDriver`.
- Closes #23: verified already implemented (`obs_indicators.rs:42-47` reads config behind RwLock per signal); no code change needed for that issue, closed via `gh issue close`.

## Why
Cleanup pass post `feat/gamepad-hot-reload`: removes magic strings, consolidates slot-extraction logic, reduces parameter sprawl in the OBS event listener, and eliminates redundant emits during continuous OBS scene switching when the same scene is reasserted.

## Notable design notes
- The shared `extract_gamepad_slot` helper falls back to `DEFAULT_GAMEPAD_SLOT` (always starts with `gamepad`). For `resolve_camera_params` the gamepad-vs-non-gamepad check is therefore done on the raw `control_id` first, before extracting the slot — the previous `""` fallback was load-bearing for that discrimination.
- `emit_and_debounce` signal parameter narrowed to `&'static str` so the change-detection map can key on the existing `signals::*` constants without owning a `String`.
- Files under 500 LOC: `event_listener.rs` 285, `connection.rs` 296, `driver.rs` 217.

## Test plan
- [x] `cargo build` clean (debug)
- [x] `cargo test` — 226 tests passing (21 lib + 193 bin + 12 integration), including 5 new tests for `extract_gamepad_slot`
- [x] `cargo clippy --all-targets` — no new warnings introduced (pre-existing baseline of warnings tracked separately by #24)
- [x] `cargo fmt` clean (pre-commit hook enforces)
- [ ] OBS hardware: scene-switching still correct (preview + program + studio mode), no missed signals
- [ ] OBS hardware: re-asserted scene events skip the debounce pipeline (verifiable via `RUST_LOG=trace`)
- [ ] Gamepad: slot resolution unchanged after refactor (test with at least one gamepad action on a configured slot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)