### PR TITLE
chore: clippy sweep — dead code removal + idiomatic fixes

### DIFF
--- a/src/api_editor/action_catalog.rs
+++ b/src/api_editor/action_catalog.rs
@@ -37,6 +37,7 @@ pub struct ParamDescriptor {
 /// Coarse parameter type used by the editor to pick an input widget.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[allow(dead_code)] // Integer/Boolean variants reserved for future driver catalogs
 pub enum ParamKind {
     String,
     Number,

--- a/src/api_editor/mod.rs
+++ b/src/api_editor/mod.rs
@@ -24,6 +24,8 @@ pub mod validate;
 
 use crate::event_bus::LiveEventTx;
 
+#[allow(unused_imports)]
+// ParamDescriptor/ParamKind are part of the public API used by tests and external callers.
 pub use action_catalog::{ActionDescriptor, ParamDescriptor, ParamKind};
 pub use actions::DriverCatalogs;
 pub use obs_picker::{ObsPickerSource, ObsPickerSourceArc};
@@ -70,6 +72,7 @@ pub struct EditorState {
 impl EditorState {
     /// Build an `EditorState` with just the profile store (used by tests and
     /// callers that wire optional fields incrementally).
+    #[allow(dead_code)] // reserved for tests and incremental wiring of optional fields
     pub fn with_profiles(profiles: Arc<crate::config::profiles::ProfileStore>) -> Self {
         Self {
             profiles,

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,12 @@ use crate::{api, display, driver_setup, helpers, input};
 ///
 /// Sets up X-Touch hardware, registers drivers, spawns the API server,
 /// and enters the core `tokio::select!` loop that handles all event sources.
+///
+/// The argument list is wide because this is the single top-level wiring
+/// site that owns every cross-cutting handle (router, config watcher, tray
+/// channels, profile store, live event bus). Bundling them into a struct
+/// would just move the boilerplate, so we accept the lint here.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_app(
     router: Arc<Router>,
     config: AppConfig,
@@ -85,6 +91,12 @@ pub async fn run_app(
         .take_event_receiver()
         .ok_or_else(|| anyhow::anyhow!("Failed to get X-Touch event receiver"))?;
 
+    // `XTouchDriver` is `!Sync` because of `MidiInputConnection`, but the `Arc`
+    // is only ever borrowed from the main task here (never moved into a
+    // `tokio::spawn`), so the lack of `Sync` is benign. We keep `Arc` (over
+    // `Rc`) so the same value can later be wired into multi-threaded paths
+    // without re-typing the entire surface.
+    #[allow(clippy::arc_with_non_send_sync)]
     let xtouch = Arc::new(xtouch);
     display::update_xtouch_display(&router, &xtouch).await;
     info!("X-Touch display initialized");

--- a/src/control_mapping.rs
+++ b/src/control_mapping.rs
@@ -5,9 +5,8 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
-use std::time::SystemTime;
+use std::path::Path;
+use std::sync::OnceLock;
 use tracing::info;
 
 /// Control mapping entry from CSV
@@ -230,6 +229,7 @@ impl ControlMappingDB {
     }
 
     /// Get all fader control IDs (fader1-fader8, fader_master)
+    #[cfg(test)]
     pub fn get_fader_controls(&self) -> Vec<&str> {
         let mut faders = Vec::new();
         for i in 1..=8 {
@@ -245,6 +245,7 @@ impl ControlMappingDB {
     }
 
     /// Get all button control IDs for a strip (mute, solo, rec, select)
+    #[cfg(test)]
     pub fn get_strip_buttons(&self, strip_num: u8) -> Vec<&str> {
         let mut buttons = Vec::new();
         for button_type in &["rec", "solo", "mute", "select"] {
@@ -255,21 +256,6 @@ impl ControlMappingDB {
         }
         buttons
     }
-
-    /// Get all encoder control IDs (vpotN_rotate, vpotN_push)
-    pub fn get_encoder_controls(&self, encoder_num: u8) -> Vec<&str> {
-        let mut controls = Vec::new();
-        let rotate_id = format!("vpot{}_rotate", encoder_num);
-        let push_id = format!("vpot{}_push", encoder_num);
-
-        if self.mappings.contains_key(&rotate_id) {
-            controls.push(self.mappings[&rotate_id].control_id.as_str());
-        }
-        if self.mappings.contains_key(&push_id) {
-            controls.push(self.mappings[&push_id].control_id.as_str());
-        }
-        controls
-    }
 }
 
 /// Default embedded CSV content (for when file is not available)
@@ -277,15 +263,6 @@ pub const DEFAULT_CSV: &str = include_str!("../docs/xtouch-matching.csv");
 
 /// Global cache for the embedded default mappings
 static DEFAULT_DB: OnceLock<ControlMappingDB> = OnceLock::new();
-
-/// In-memory cache for on-disk CSV (path + mtime)
-struct FileCache {
-    path: PathBuf,
-    mtime: SystemTime,
-    db: ControlMappingDB,
-}
-
-static FILE_DB: OnceLock<Mutex<Option<FileCache>>> = OnceLock::new();
 
 /// Load the default control mappings (cached after first parse)
 ///
@@ -306,50 +283,6 @@ pub fn load_default_mappings() -> Result<&'static ControlMappingDB> {
 pub fn warm_default_mappings() -> Result<()> {
     let _ = load_default_mappings()?;
     Ok(())
-}
-
-/// Load mappings from a CSV path, re-parsing only when the file changed.
-pub async fn load_mappings_from_path(path: impl AsRef<Path>) -> Result<ControlMappingDB> {
-    let path = path.as_ref().to_path_buf();
-
-    // Check file metadata (mtime)
-    let meta = tokio::fs::metadata(&path)
-        .await
-        .with_context(|| format!("Failed to stat CSV file: {}", path.display()))?;
-    let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
-
-    let cache = FILE_DB.get_or_init(|| Mutex::new(None));
-    {
-        let guard = cache.lock().expect("cache mutex poisoned");
-        if let Some(FileCache {
-            path: cached_path,
-            mtime: cached_mtime,
-            db,
-        }) = guard.as_ref()
-        {
-            if *cached_path == path && *cached_mtime == mtime {
-                return Ok(db.clone());
-            }
-        }
-    }
-
-    // Not cached or outdated -> re-read
-    let csv_content = tokio::fs::read_to_string(&path)
-        .await
-        .with_context(|| format!("Failed to read CSV file: {}", path.display()))?;
-    let db = ControlMappingDB::parse_csv(&csv_content)?;
-
-    // Update cache
-    {
-        let mut guard = cache.lock().expect("cache mutex poisoned");
-        *guard = Some(FileCache {
-            path,
-            mtime,
-            db: db.clone(),
-        });
-    }
-
-    Ok(db)
 }
 
 #[cfg(test)]

--- a/src/drivers/console.rs
+++ b/src/drivers/console.rs
@@ -1,4 +1,9 @@
 //! Console driver - logs all actions for testing and debugging
+//!
+//! This driver is consumed by integration/unit tests (see `src/router/tests.rs`).
+//! In a non-test bin build it is unreferenced, so we silence dead-code lints here.
+
+#![allow(dead_code)]
 
 use crate::drivers::{Driver, ExecutionContext};
 use anyhow::Result;

--- a/src/drivers/midibridge.rs
+++ b/src/drivers/midibridge.rs
@@ -549,21 +549,18 @@ impl Driver for MidiBridgeDriver {
         match action {
             "passthrough" => {
                 // Extract raw MIDI bytes from context value
-                if let Some(value) = ctx.value {
-                    if let Value::Array(bytes_array) = value {
-                        let bytes: Vec<u8> = bytes_array
-                            .iter()
-                            .filter_map(|v| v.as_u64().map(|n| n as u8))
-                            .collect();
-                        if !bytes.is_empty() {
-                            debug!("→ Passthrough {} bytes to '{}'", bytes.len(), self.to_port);
-                            self.send_message(&bytes)?;
+                if let Some(Value::Array(bytes_array)) = ctx.value {
+                    let bytes: Vec<u8> = bytes_array
+                        .iter()
+                        .filter_map(|v| v.as_u64().map(|n| n as u8))
+                        .collect();
+                    if !bytes.is_empty() {
+                        debug!("→ Passthrough {} bytes to '{}'", bytes.len(), self.to_port);
+                        self.send_message(&bytes)?;
 
-                            // Record outbound activity
-                            if let Some(ref tracker) = ctx.activity_tracker {
-                                tracker
-                                    .record(&self.name, crate::tray::ActivityDirection::Outbound);
-                            }
+                        // Record outbound activity
+                        if let Some(ref tracker) = ctx.activity_tracker {
+                            tracker.record(&self.name, crate::tray::ActivityDirection::Outbound);
                         }
                     }
                 }

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -21,6 +21,7 @@ pub type IndicatorCallback = Arc<dyn Fn(String, Value) + Send + Sync>;
 
 /// Execution context passed to drivers for accessing router state and config
 #[derive(Clone)]
+#[allow(dead_code)] // `config` and `active_page` are part of the public driver API (consumed by tests and 3rd-party drivers).
 pub struct ExecutionContext {
     /// Application configuration
     pub config: Arc<RwLock<crate::config::AppConfig>>,
@@ -92,6 +93,7 @@ pub trait Driver: Send + Sync {
     ///
     /// Returns the current connection state of the driver.
     /// Default implementation: always connected (for drivers without network connections)
+    #[allow(dead_code)] // reserved for tray UI polling — currently driven by `subscribe_connection_status`
     fn connection_status(&self) -> crate::tray::ConnectionStatus {
         crate::tray::ConnectionStatus::Connected
     }
@@ -123,9 +125,13 @@ pub mod obs;
 pub mod winaudio;
 pub mod winmedia;
 
-// Re-export commonly used drivers
+// Re-export commonly used drivers (used by tests and external consumers).
+#[allow(unused_imports)]
 pub use console::ConsoleDriver;
+#[allow(unused_imports)]
 pub use midibridge::MidiBridgeDriver;
 pub use obs::ObsDriver;
+#[allow(unused_imports)]
 pub use winaudio::WinAudioDriver;
+#[allow(unused_imports)]
 pub use winmedia::WinMediaDriver;

--- a/src/drivers/obs/analog.rs
+++ b/src/drivers/obs/analog.rs
@@ -25,7 +25,7 @@ pub(super) fn shape_analog(value: f64, gamma: f64) -> f64 {
     }
 
     let sign = if value >= 0.0 { 1.0 } else { -1.0 };
-    let magnitude = value.abs().min(1.0).max(0.0);
+    let magnitude = value.abs().clamp(0.0, 1.0);
 
     // Apply gamma curve for finer control at low values
     let shaped = magnitude.powf(gamma);

--- a/src/drivers/obs/driver.rs
+++ b/src/drivers/obs/driver.rs
@@ -149,6 +149,7 @@ impl ObsDriver {
     }
 
     /// Load analog config from gamepad settings
+    #[allow(dead_code)] // reserved for hot-reload of gamepad analog tuning (currently set at init)
     pub fn load_analog_config(&self, gamepad_config: Option<&crate::config::GamepadConfig>) {
         if let Some(gamepad) = gamepad_config {
             if let Some(analog) = &gamepad.analog {

--- a/src/drivers/obs/ptz_actions.rs
+++ b/src/drivers/obs/ptz_actions.rs
@@ -201,17 +201,16 @@ impl ObsDriver {
         let (canvas_width, canvas_height) = self.get_canvas_dimensions().await?;
 
         // Build transform to reset position to center
-        let mut transform = obws::requests::scene_items::SceneItemTransform::default();
-
-        // Set alignment to center (so position refers to object center, not corner)
-        transform.alignment = Some(obws::common::Alignment::CENTER);
-
-        // Set position to canvas center
-        transform.position = Some(obws::requests::scene_items::Position {
-            x: Some((canvas_width / 2.0) as f32),
-            y: Some((canvas_height / 2.0) as f32),
+        let transform = obws::requests::scene_items::SceneItemTransform {
+            // Set alignment to center (so position refers to object center, not corner)
+            alignment: Some(obws::common::Alignment::CENTER),
+            // Set position to canvas center
+            position: Some(obws::requests::scene_items::Position {
+                x: Some((canvas_width / 2.0) as f32),
+                y: Some((canvas_height / 2.0) as f32),
+            }),
             ..Default::default()
-        });
+        };
 
         // Send to OBS
         let guard = self.get_connected_client().await?;
@@ -301,7 +300,6 @@ impl ObsDriver {
             transform.scale = Some(obws::requests::scene_items::Scale {
                 x: Some(1.0),
                 y: Some(1.0),
-                ..Default::default()
             });
             debug!("OBS Reset zoom (scale): 1.0x1.0");
         }

--- a/src/drivers/obs/transform.rs
+++ b/src/drivers/obs/transform.rs
@@ -295,8 +295,8 @@ impl ObsDriver {
                     current.x, current.y, new_state.x, new_state.y);
             } else {
                 // PATH 2: Scale-based scaling
-                new_state.scale_x = (current.scale_x * factor).max(0.01).min(10.0);
-                new_state.scale_y = (current.scale_y * factor).max(0.01).min(10.0);
+                new_state.scale_x = (current.scale_x * factor).clamp(0.01, 10.0);
+                new_state.scale_y = (current.scale_y * factor).clamp(0.01, 10.0);
 
                 // Calculate effective factor (may be capped by scale limits)
                 // If scale hits a limit (min 0.01 or max 10.0), the effective factor differs from requested
@@ -376,7 +376,6 @@ impl ObsDriver {
             transform.position = Some(obws::requests::scene_items::Position {
                 x: Some(new_state.x as f32),
                 y: Some(new_state.y as f32),
-                ..Default::default()
             });
         }
 
@@ -396,7 +395,6 @@ impl ObsDriver {
                     transform.scale = Some(obws::requests::scene_items::Scale {
                         x: Some(new_state.scale_x as f32),
                         y: Some(new_state.scale_y as f32),
-                        ..Default::default()
                     });
                 }
             } else {
@@ -404,7 +402,6 @@ impl ObsDriver {
                 transform.scale = Some(obws::requests::scene_items::Scale {
                     x: Some(new_state.scale_x as f32),
                     y: Some(new_state.scale_y as f32),
-                    ..Default::default()
                 });
                 debug!(
                     "OBS sending SCALE transform: {:.3}×{:.3}",
@@ -547,7 +544,6 @@ impl ObsDriver {
             transform.position = Some(obws::requests::scene_items::Position {
                 x: Some(new_state.x as f32),
                 y: Some(new_state.y as f32),
-                ..Default::default()
             });
         }
 
@@ -562,7 +558,6 @@ impl ObsDriver {
                 transform.scale = Some(obws::requests::scene_items::Scale {
                     x: Some(new_state.scale_x as f32),
                     y: Some(new_state.scale_y as f32),
-                    ..Default::default()
                 });
             }
         }

--- a/src/drivers/winmedia/mod.rs
+++ b/src/drivers/winmedia/mod.rs
@@ -33,9 +33,12 @@ pub const DRIVER_NAME: &str = "winmedia";
 /// keeping per-tick CPU work negligible.
 const SMTC_POLL_INTERVAL_MS: u64 = 500;
 
-/// Action name used to look up the play/pause control on the active
-/// page when the driver wants to emit an LED indicator.
-const PLAY_PAUSE_ACTION: &str = "play_pause";
+/// Synthetic feedback channel used to inject `("winmedia", note_on_bytes)`
+/// updates into the unified router feedback pipeline.
+type FeedbackSender = mpsc::Sender<(String, Vec<u8>)>;
+
+/// Shared optional handle to a feedback sender, populated by `set_feedback_sender`.
+type SharedFeedbackTx = Arc<RwLock<Option<FeedbackSender>>>;
 
 pub struct WinMediaDriver {
     initialized: AtomicBool,
@@ -48,7 +51,7 @@ pub struct WinMediaDriver {
     /// Wired post-construction. The polling task uses this to inject
     /// synthetic `("winmedia", note_on_bytes)` feedback into the unified
     /// router feedback path.
-    feedback_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<u8>)>>>>,
+    feedback_tx: SharedFeedbackTx,
     /// Wired post-construction. Reused for every play-LED resolution
     /// instead of reloading from disk on each emit.
     control_db: Arc<RwLock<Option<Arc<crate::control_mapping::ControlMappingDB>>>>,
@@ -372,7 +375,7 @@ fn read_smtc_playing() -> bool {
 /// spec, then emit a NoteOn feedback message that lights (vel 127) or
 /// extinguishes (vel 0) the bound X-Touch button LED.
 async fn emit_play_indicator(
-    feedback_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<u8>)>>>>,
+    feedback_tx: &SharedFeedbackTx,
     router: &Arc<RwLock<Option<Arc<crate::router::Router>>>>,
     control_db: &Arc<RwLock<Option<Arc<crate::control_mapping::ControlMappingDB>>>>,
     playing: bool,

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -37,6 +37,7 @@ pub enum LiveEvent {
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[allow(dead_code)] // `Encoder` reserved for future encoder-press hardware events
 pub enum HwEventKind {
     Press,
     Release,

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -319,16 +319,6 @@ impl MidiMessage {
             _ => None,
         }
     }
-
-    /// Check if this is a channel message
-    pub fn is_channel_message(&self) -> bool {
-        self.channel().is_some()
-    }
-
-    /// Check if this is a system message
-    pub fn is_system_message(&self) -> bool {
-        !self.is_channel_message()
-    }
 }
 
 impl fmt::Display for MidiMessage {
@@ -383,8 +373,11 @@ impl fmt::Display for MidiMessage {
 
 /// MIDI value conversion utilities
 pub mod convert {
-    /// Convert 14-bit value (0-16383) to 7-bit value (0-127) using bit shift
-    /// Note: This uses bit shift and may lose precision. Use to_7bit_from_14bit() for precise conversion.
+    /// Convert 14-bit value (0-16383) to 7-bit value (0-127) using bit shift.
+    ///
+    /// This uses bit shift and may lose precision. Use [`to_7bit_from_14bit`] for
+    /// rounded conversion.
+    #[cfg(test)]
     pub fn to_7bit(value_14bit: u16) -> u8 {
         ((value_14bit >> 7) & 0x7F) as u8
     }
@@ -394,13 +387,6 @@ pub mod convert {
     pub fn to_7bit_from_14bit(value_14bit: u16) -> u8 {
         let clamped = value_14bit.min(16383);
         ((clamped as f32 / 16383.0) * 127.0).round() as u8
-    }
-
-    /// Convert 14-bit value (0-16383) to 8-bit value (0-255) with proper rounding
-    /// Matches TypeScript to8bitFrom14bit(): Math.round((v / 16383) * 255)
-    pub fn to_8bit_from_14bit(value_14bit: u16) -> u8 {
-        let clamped = value_14bit.min(16383);
-        ((clamped as f32 / 16383.0) * 255.0).round() as u8
     }
 
     /// Convert 7-bit value (0-127) to 14-bit value (0-16383)
@@ -429,16 +415,6 @@ pub mod convert {
     /// Convert percentage to 7-bit value
     pub fn from_percent_7bit(percent: f32) -> u8 {
         ((percent.clamp(0.0, 100.0) * 127.0) / 100.0).round() as u8
-    }
-
-    /// Convert 14-bit value to 8-bit value (0-255) - for 8-bit CC mode
-    pub fn to_8bit(value_14bit: u16) -> u8 {
-        ((value_14bit >> 6) & 0xFF) as u8
-    }
-
-    /// Convert 8-bit value to 14-bit value
-    pub fn from_8bit(value_8bit: u8) -> u16 {
-        (value_8bit as u16) << 6
     }
 
     /// Convert config channel (1-based) to MIDI channel (0-based)
@@ -478,32 +454,12 @@ pub fn pb14_from_raw(lsb: u8, msb: u8) -> u16 {
     ((msb as u16) << 7) | (lsb as u16)
 }
 
-/// Deconstruct a 14-bit value into LSB and MSB bytes
-pub fn pb14_to_bytes(value: u16) -> (u8, u8) {
-    let lsb = (value & 0x7F) as u8;
-    let msb = ((value >> 7) & 0x7F) as u8;
-    (lsb, msb)
-}
-
 /// Format MIDI bytes as hex string for debugging
 pub fn format_hex(data: &[u8]) -> String {
     data.iter()
         .map(|b| format!("{:02X}", b))
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-/// Format MIDI message for sniffer output
-pub fn format_sniffer(timestamp_ms: u64, direction: &str, port: &str, data: &[u8]) -> String {
-    let hex = format_hex(data);
-    let message = MidiMessage::parse(data)
-        .map(|m| format!(" => {}", m))
-        .unwrap_or_default();
-
-    format!(
-        "[{:08}ms] {} {} | {}{}",
-        timestamp_ms, direction, port, hex, message
-    )
 }
 
 /// Find a MIDI output port by substring matching (case-insensitive)
@@ -547,22 +503,6 @@ impl MidiMessage {
                 velocity
             },
             _ => 0,
-        }
-    }
-
-    /// Get the controller number for CC messages
-    pub fn controller(&self) -> Option<u8> {
-        match *self {
-            MidiMessage::ControlChange { cc, .. } => Some(cc),
-            _ => None,
-        }
-    }
-
-    /// Get the value for CC messages
-    pub fn value(&self) -> Option<u8> {
-        match *self {
-            MidiMessage::ControlChange { value, .. } => Some(value),
-            _ => None,
         }
     }
 }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -73,6 +73,7 @@ pub struct Router {
 
 impl Router {
     /// Create a new Router with initial configuration
+    #[allow(dead_code)] // exercised by `router::tests`; production uses `with_db_path`
     pub fn new(config: AppConfig) -> Result<Self> {
         Self::with_db_path(config, ".state/sled")
     }
@@ -181,6 +182,7 @@ impl Router {
     /// The two SysEx messages produced are appended to `pending_midi_messages`
     /// and `display_refresh_notify` is signalled so the main loop flushes
     /// them to the X-Touch on its next pass.
+    #[allow(dead_code)] // reserved for driver-driven LCD overlays (winaudio, winmedia indicators)
     pub async fn push_lcd_label(&self, channel: u8, upper: &str, lower: &str) {
         if !(1..=8).contains(&channel) {
             tracing::warn!("push_lcd_label: invalid channel {} (1..=8)", channel);

--- a/src/router/page.rs
+++ b/src/router/page.rs
@@ -49,6 +49,7 @@ impl super::Router {
     /// the currently active page. Returns an empty set if no page is active.
     ///
     /// Used by main.rs to filter state updates to only apps on the active page.
+    #[allow(dead_code)] // reserved for state-update filtering (per AUDIT_STATE_PROGRESS.md); tests rely on `get_apps_for_page`
     pub async fn get_apps_for_active_page(&self) -> HashSet<String> {
         let config = self.config.read().await;
         let index = *self.active_page_index.read().await;
@@ -60,6 +61,7 @@ impl super::Router {
     }
 
     /// List all page names
+    #[allow(dead_code)] // exercised by `router::tests`; reserved for REPL/CLI page-listing
     pub async fn list_pages(&self) -> Vec<String> {
         let config = self.config.read().await;
         config.pages.iter().map(|p| p.name.clone()).collect()

--- a/src/router/xtouch_input.rs
+++ b/src/router/xtouch_input.rs
@@ -275,14 +275,12 @@ impl super::Router {
                 }
             },
             crate::config::MidiType::Pb => {
-                if let Some(ch) = target_spec.channel {
-                    Some(crate::midi::MidiMessage::PitchBend {
+                target_spec
+                    .channel
+                    .map(|ch| crate::midi::MidiMessage::PitchBend {
                         channel: config_channel_to_midi(ch),
                         value: denormalize_to_14bit(normalized_value),
                     })
-                } else {
-                    None
-                }
             },
             crate::config::MidiType::Passthrough => {
                 // Raw passthrough (no transformation)

--- a/src/sniffer.rs
+++ b/src/sniffer.rs
@@ -20,6 +20,7 @@ use crate::xtouch::discovery;
 
 /// Direction of MIDI message
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // `Output`/`Bidirectional` reserved for future sniffer-emitted/round-trip events
 pub enum Direction {
     Input,
     Output,

--- a/src/state/actor.rs
+++ b/src/state/actor.rs
@@ -103,9 +103,6 @@ pub struct StateActor {
     /// Receiver for incoming commands
     command_rx: mpsc::Receiver<StateCommand>,
 
-    /// Sender for persistence commands
-    persistence_tx: mpsc::Sender<PersistenceCommand>,
-
     /// Counter for tracking total updates processed
     update_count: u64,
 
@@ -124,7 +121,9 @@ impl StateActor {
     ///
     /// # Arguments
     ///
-    /// * `persistence_tx` - Channel for sending persistence commands
+    /// * `_persistence_tx` - Reserved for future direct persistence wiring.
+    ///   Currently kept in the signature so callers don't break, but writes
+    ///   are routed through `PersistenceActorHandle` directly today.
     ///
     /// # Returns
     ///
@@ -136,7 +135,7 @@ impl StateActor {
     /// let (persist_tx, persist_rx) = mpsc::channel(16);
     /// let handle = StateActor::spawn(persist_tx);
     /// ```
-    pub fn spawn(persistence_tx: mpsc::Sender<PersistenceCommand>) -> StateActorHandle {
+    pub fn spawn(_persistence_tx: mpsc::Sender<PersistenceCommand>) -> StateActorHandle {
         let (cmd_tx, cmd_rx) = mpsc::channel(STATE_COMMAND_CHANNEL_CAPACITY);
 
         // Initialize state storage for all known apps
@@ -151,7 +150,6 @@ impl StateActor {
             app_shadows: HashMap::new(),
             last_user_action_ts: HashMap::new(),
             command_rx: cmd_rx,
-            persistence_tx,
             update_count: 0,
             last_gc_user_action: None,
             last_gc_shadows: None,

--- a/src/state/actor_handle.rs
+++ b/src/state/actor_handle.rs
@@ -3,6 +3,13 @@
 //! Provides an ergonomic async interface for interacting with the StateActor
 //! through message passing. Fire-and-forget methods for hot paths, and
 //! async methods with oneshot channels for queries.
+//!
+//! Several query methods (`get_state`, `list_states`, `should_suppress_lww`,
+//! `hydrate_from_snapshot`, `clear_all_states`, `shutdown`) are part of the
+//! public actor surface but currently have no in-tree caller. They are kept
+//! for future API consumers (REPL, editor, hot-reload) and tests.
+
+#![allow(dead_code)]
 
 use std::collections::HashMap;
 

--- a/src/state/commands.rs
+++ b/src/state/commands.rs
@@ -3,6 +3,13 @@
 //! These commands enable message-passing architectures for state management,
 //! separating the hot path (fire-and-forget updates) from request-response
 //! operations that need acknowledgment.
+//!
+//! Some variants (`GetState`, `ListStates`, `CheckSuppressLWW`,
+//! `ClearAllStates`, `Shutdown`) are part of the actor protocol but currently
+//! never constructed in-tree — they're kept to avoid breaking the actor API
+//! surface and for future use by external callers (REPL, tests).
+
+#![allow(dead_code)]
 
 use super::types::{AppKey, MidiAddr, MidiStateEntry, MidiStatus};
 use std::collections::HashMap;

--- a/src/state/persistence_actor.rs
+++ b/src/state/persistence_actor.rs
@@ -55,6 +55,7 @@ const SNAPSHOT_KEY: &[u8] = b"state_snapshot";
 
 /// Commands sent to the persistence actor
 #[derive(Debug)]
+#[allow(dead_code)] // `Shutdown` variant only used by tests today; kept for graceful-shutdown wiring
 pub enum PersistenceCommand {
     /// Save a state snapshot (debounced)
     Save(StateSnapshot),
@@ -287,6 +288,7 @@ impl PersistenceActor {
     /// # Errors
     ///
     /// Returns an error if serialization or database write fails.
+    #[allow(dead_code)] // reserved for synchronous flush paths (tests, graceful shutdown)
     fn write_snapshot(&self, snapshot: &StateSnapshot) -> Result<()> {
         let json = serde_json::to_vec(snapshot).context("Failed to serialize snapshot")?;
 
@@ -362,6 +364,7 @@ impl PersistenceActorHandle {
     /// This is a fire-and-forget operation. The actor will flush any pending
     /// snapshot before terminating. Use [`flush`](Self::flush) first if you
     /// need to ensure persistence completes.
+    #[allow(dead_code)] // exercised by tests; reserved for graceful shutdown wiring
     pub fn shutdown(&self) {
         // Best-effort send, ignore errors if already shut down
         let _ = self.cmd_tx.try_send(PersistenceCommand::Shutdown);

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -77,6 +77,7 @@ impl MidiValue {
     }
 
     /// Extract binary data if available
+    #[allow(dead_code)] // mirror of `as_number` for SysEx values; kept for symmetry/external API
     pub fn as_binary(&self) -> Option<&[u8]> {
         match self {
             MidiValue::Binary(b) => Some(b),
@@ -186,6 +187,7 @@ pub fn addr_key(addr: &MidiAddr) -> String {
 }
 
 /// Constructs a key without the port (for X-Touch shadow state)
+#[allow(dead_code)] // helper kept alongside `addr_key`; reserved for callers that don't track port
 pub fn addr_key_without_port(addr: &MidiAddr) -> String {
     format!(
         "{}|{}|{}",

--- a/src/tray/activity.rs
+++ b/src/tray/activity.rs
@@ -86,6 +86,7 @@ impl ActivityTracker {
     /// Get the last activity timestamp for a driver+direction
     ///
     /// Returns None if no activity has been recorded.
+    #[allow(dead_code)] // exercised by unit tests; reserved for tray UI diagnostics
     pub fn last_activity(&self, driver: &str, direction: ActivityDirection) -> Option<Instant> {
         let key = format!("{}:{:?}", driver, direction);
         self.activity_map.get(&key).map(|entry| *entry.value())
@@ -94,16 +95,19 @@ impl ActivityTracker {
     /// Clear all activity records
     ///
     /// Useful for resetting the tracker or cleanup.
+    #[allow(dead_code)] // exercised by unit tests; reserved for tray reset paths
     pub fn clear(&self) {
         self.activity_map.clear();
     }
 
     /// Get the number of tracked activities
+    #[allow(dead_code)] // diagnostics helper; symmetric with `is_empty`
     pub fn len(&self) -> usize {
         self.activity_map.len()
     }
 
     /// Check if the tracker is empty
+    #[allow(dead_code)] // diagnostics helper; symmetric with `len`
     pub fn is_empty(&self) -> bool {
         self.activity_map.is_empty()
     }

--- a/src/tray/handler.rs
+++ b/src/tray/handler.rs
@@ -138,11 +138,13 @@ impl TrayMessageHandler {
     }
 
     /// Get current status of all drivers
+    #[allow(dead_code)] // diagnostics / future tray-UI batch query
     pub fn get_all_statuses(&self) -> HashMap<String, ConnectionStatus> {
         self.driver_statuses.read().clone()
     }
 
     /// Send initial status for a driver (used when driver is first initialized)
+    #[allow(dead_code)] // reserved for explicit driver-init wiring; subscribers currently push status
     pub fn send_initial_status(&self, driver_name: String, status: ConnectionStatus) {
         trace!(
             "TrayHandler: sending initial status for {}: {:?}",

--- a/src/tray/manager.rs
+++ b/src/tray/manager.rs
@@ -3,7 +3,6 @@
 //! Runs on a dedicated OS thread to handle Win32 message loop.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use tracing::{debug, trace, warn};
 
 use super::{ActivityDirection, ConnectionStatus, TrayCommand, TrayUpdate};
@@ -91,11 +90,11 @@ impl TrayManager {
         tray_icon.set_menu(Some(Box::new(menu.clone())));
         debug!("Menu attached to tray icon");
 
-        // Store menu for later updates
-        let menu = Arc::new(parking_lot::Mutex::new(menu));
-
-        // Clone for event handler
-        let menu_clone = Arc::clone(&menu);
+        // Store menu for later updates. The tray manager's event loop is
+        // single-threaded (Windows message pump) so a plain `Mutex` is
+        // sufficient — no `Arc` needed (the previous wrapper triggered
+        // `clippy::arc_with_non_send_sync` because `muda::Menu` is `!Sync`).
+        let menu_cell = parking_lot::Mutex::new(menu);
 
         // Get menu event receiver
         let menu_channel = muda::MenuEvent::receiver();
@@ -142,7 +141,7 @@ impl TrayManager {
                         // Rebuild menu to reflect new setting
                         if let Ok(new_menu) = self.build_menu_with_all_statuses() {
                             tray_icon.set_menu(Some(Box::new(new_menu.clone())));
-                            *menu_clone.lock() = new_menu;
+                            *menu_cell.lock() = new_menu;
                         }
                     },
                     "toggle_connection_status" => {
@@ -160,7 +159,7 @@ impl TrayManager {
                         // Rebuild menu to reflect new setting
                         if let Ok(new_menu) = self.build_menu_with_all_statuses() {
                             tray_icon.set_menu(Some(Box::new(new_menu.clone())));
-                            *menu_clone.lock() = new_menu;
+                            *menu_cell.lock() = new_menu;
                         }
                     },
                     "about" => {
@@ -231,7 +230,7 @@ impl TrayManager {
                     if let Ok(new_menu) = self.build_menu_with_all_statuses() {
                         let item_count = new_menu.items().len();
                         tray_icon.set_menu(Some(Box::new(new_menu.clone())));
-                        *menu_clone.lock() = new_menu;
+                        *menu_cell.lock() = new_menu;
                         trace!("Menu rebuilt with {} items", item_count);
                     }
                 },
@@ -250,7 +249,7 @@ impl TrayManager {
                     if new_hash != self.last_menu_hash {
                         if let Ok(new_menu) = self.build_menu_with_all_statuses() {
                             tray_icon.set_menu(Some(Box::new(new_menu.clone())));
-                            *menu_clone.lock() = new_menu;
+                            *menu_cell.lock() = new_menu;
                             self.last_menu_hash = new_hash;
                             trace!(
                                 "Menu rebuilt (hash changed: {} -> {})",
@@ -270,7 +269,7 @@ impl TrayManager {
                     self.active_profile = active;
                     if let Ok(new_menu) = self.build_menu_with_all_statuses() {
                         tray_icon.set_menu(Some(Box::new(new_menu.clone())));
-                        *menu_clone.lock() = new_menu;
+                        *menu_cell.lock() = new_menu;
                         self.last_menu_hash = self.calculate_menu_hash();
                     }
                 },

--- a/src/xtouch.rs
+++ b/src/xtouch.rs
@@ -19,6 +19,7 @@ use crate::midi::{format_hex, MidiMessage};
 
 /// MIDI event from X-Touch
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // `timestamp`/`message` are part of the public event payload (consumers may inspect them)
 pub struct XTouchEvent {
     pub timestamp: Instant,
     pub message: MidiMessage,
@@ -76,6 +77,7 @@ impl XTouchDriver {
     }
 
     /// List available MIDI input ports
+    #[allow(dead_code)] // diagnostics helper exposed by the driver; reserved for CLI/tests
     pub fn list_input_ports() -> Result<Vec<String>> {
         let midi_in = MidiInput::new("XTouch-GW-Scanner")?;
         Ok(midi_in
@@ -86,6 +88,7 @@ impl XTouchDriver {
     }
 
     /// List available MIDI output ports
+    #[allow(dead_code)] // diagnostics helper exposed by the driver; reserved for CLI/tests
     pub fn list_output_ports() -> Result<Vec<String>> {
         let midi_out = MidiOutput::new("XTouch-GW-Scanner")?;
         Ok(midi_out
@@ -235,6 +238,7 @@ impl XTouchDriver {
     }
 
     /// Check if connected
+    #[allow(dead_code)] // status helper; reserved for tray UI and diagnostics
     pub fn is_connected(&self) -> bool {
         self.input_conn.is_some() && self.output_conn.is_some()
     }
@@ -260,6 +264,7 @@ impl XTouchDriver {
     ///
     /// Used for feedback routing from MIDI bridge drivers.
     /// This is a non-async version safe to call from within MIDI callbacks.
+    #[allow(dead_code)] // reserved for sync-callback feedback paths (currently routed through async send_raw)
     pub fn send_raw_sync(&self, data: &[u8]) -> Result<()> {
         let output = self
             .output_conn
@@ -371,6 +376,7 @@ impl XTouchDriver {
     }
 
     /// Set encoder LED ring (0-11 for position, 12-15 for modes)
+    #[allow(dead_code)] // public driver API; reserved for encoder-LED indicator wiring
     pub async fn set_encoder_led(&self, encoder: u8, value: u8) -> Result<()> {
         if encoder > 7 {
             bail!("Invalid encoder number: {} (must be 0-7)", encoder);
@@ -405,6 +411,7 @@ impl XTouchDriver {
     }
 
     /// Send only lower line LCD text (for value overlay)
+    #[allow(dead_code)] // public driver API; reserved for partial-LCD overlay paths (top line preserved)
     pub async fn send_lcd_strip_lower_text(&self, strip_index: u8, lower: &str) -> Result<()> {
         if strip_index > 7 {
             bail!("Invalid LCD strip index: {} (must be 0-7)", strip_index);

--- a/src/xtouch/fader_setpoint.rs
+++ b/src/xtouch/fader_setpoint.rs
@@ -178,6 +178,7 @@ impl FaderSetpoint {
     }
 
     /// Get the current epoch for a channel (for debugging)
+    #[allow(dead_code)] // diagnostics helper; symmetric with `is_epoch_current`
     pub fn get_epoch(&self, channel: u8) -> Option<u32> {
         let channels = self.channels.read().unwrap();
         channels.get(&channel).map(|state| state.epoch)

--- a/tests/editor_api.rs
+++ b/tests/editor_api.rs
@@ -194,7 +194,7 @@ async fn validate_rejects_bad_yaml() {
     .await;
     assert_eq!(s, StatusCode::OK);
     assert_eq!(body["ok"], false);
-    assert!(body["errors"].as_array().unwrap().len() >= 1);
+    assert!(!body["errors"].as_array().unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #24 partially. Cleans up clippy warnings across the codebase, **excluding files currently owned by open PRs #46, #47, #48** (and the upcoming PR-W2 zone for #38). Those will be cleaned up in a follow-up PR after the wave 1 PRs merge.

**Stats**: 99 clippy warnings (incl. dupes) before -> 27 after. All remaining warnings live in OFF-LIMITS files.

## Categories addressed

- **Dead code (deletion)**: removed truly-unused helpers from `midi.rs` (`to_8bit`, `from_8bit`, `to_8bit_from_14bit`, `pb14_to_bytes`, `format_sniffer`, `controller`, `value`, `is_channel_message`, `is_system_message`) and `control_mapping.rs` (`FileCache`, `FILE_DB`, `load_mappings_from_path`, `get_encoder_controls`). Dropped the dead `persistence_tx` field from `StateActor`.
- **Dead code (gating)**: `#[cfg(test)]` for test-only helpers in `midi.rs` and `control_mapping.rs`.
- **Dead code (allow + rationale)**: `#[allow(dead_code)]` with comments for items reserved for future use or only consumed by tests, in `event_bus`, `sniffer`, `state/*`, `tray/*`, `router/*`, `xtouch`, `xtouch/fader_setpoint`, `drivers/console`, `drivers/mod`, `drivers/obs/driver`, `drivers/winmedia`, `api_editor/*`.
- **Style**: `len() >= 1` -> `!is_empty()`, `.min(x).max(y)` -> `.clamp()`, collapsed nested `if let`, manual `Option::map` -> `.map()`, `field_reassign_with_default` -> struct literal, dropped redundant `..Default::default()`, type-aliased complex tuple sender in `winmedia`.
- **Correctness**: investigated both `clippy::arc_with_non_send_sync` warnings:
  - `tray/manager.rs`: real smell — the `Arc<Mutex<muda::Menu>>` was unnecessary because the tray runs single-threaded; replaced with a plain `parking_lot::Mutex`.
  - `app.rs`: benign — `Arc<XTouchDriver>` is `!Sync` because of `MidiInputConnection` on Windows but the Arc never crosses task boundaries; annotated with `#[allow]` + comment.
- Annotated `run_app`'s 9-arg signature with `#[allow(clippy::too_many_arguments)]` (top-level wiring site, bundling would just move boilerplate).

## Warnings deferred (in OFF-LIMITS files, fix in follow-up PR-C2)

After wave 1 PRs (#46, #47, #48) and PR-W2 (#38) merge, these can be addressed:

- `src/drivers/winaudio/*` (5 duplicated-attribute warnings, `SlotBinding` struct + `display_name` field never read, `compute_slots` fn never used, `needless_range_loop` in mapping, `type_complexity` on `feedback_tx`) — owned by PR #48
- `src/router/refresh_plan.rs` (2× `needless_borrow` of `mapping_db`) — owned by PR #47
- `src/router/camera_target.rs` (`get_all_targets`, `clear_target` never used) — owned by PR #46
- `src/input/gamepad/*` (`to_midi_cc`, `to_midi_pb`, `button_to_midi`, `print_gamepad_diagnostics`, `sequence` field, `RadialClamp`/`AstroidToCircle` variants, `slots`/`len`/`is_empty` methods, `gamepad_id` field, `to_string` + `inherent_to_string`, `or_insert_with` -> `or_default`, `bool_assert_comparison`) — owned by PR #46
- `src/drivers/obs/camera_actions.rs` (unused import: `debug`) — owned by PR #46
- `src/obs_indicators.rs` (`too_many_arguments`, `collapsible_match`) — owned by PR #46
- `src/config/mod.rs` (method `save` never used) — touched by upcoming PR-W2

The `gamepad_mapper assigned but never read` regression mentioned in #24 was not visible in this run; if it resurfaces, it lives in `src/input/gamepad/` and belongs to PR #46.

## Stats

- Warnings before: **99** (cargo clippy --all-targets, with duplicates)
- Warnings after (in this PR's scope): **0**
- Warnings remaining (out of scope, owned by other PRs): **27**

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` clean (188 lib + 21 + 12 integration tests pass)
- [x] `cargo clippy --all-targets` clean for in-scope files
- [ ] Hardware: smoke test that no dead-code-removed helper broke runtime (no callers found via `grep`, but worth a sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)