### PR TITLE
feat(winaudio): quality + refactor (auto-detect, validation, split)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -230,6 +230,16 @@ pub async fn run_app(
     // switches; receiver lives in the main loop until shutdown.
     debug!("All drivers registered and initialized");
 
+    // Notify late-starting drivers that the startup profile is fully
+    // settled (config parsed, router built, all drivers registered).
+    // The winaudio driver awaits this to refresh master + session state
+    // without racing the page filter. Best-effort: failing to broadcast
+    // (no subscribers) just means no one was listening yet.
+    let _ = live_tx.send(crate::event_bus::LiveEvent::ProfileLoaded {
+        profile_name: None,
+        ts: crate::event_bus::now_ms(),
+    });
+
     // Spawn Stream Deck API server task
     let api_port = api::DEFAULT_API_PORT;
     tokio::spawn({

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -668,6 +668,29 @@ impl AppConfig {
             }
         }
 
+        // Validate winaudio session-target params (e.g. `pinned:1`,
+        // `discovered:3`, `auto`) at config-load. Typos previously
+        // surfaced only when the user pressed the button (#38).
+        self.validate_winaudio_session_targets()?;
+
+        Ok(())
+    }
+
+    /// Iterate every page (and `pages_global`) for control mappings
+    /// bound to `app: "winaudio"` and a session-target action; parse
+    /// their first param via [`parse_session_target`]. Errors carry
+    /// `page` + `control_id` context so the user can fix the YAML.
+    fn validate_winaudio_session_targets(&self) -> Result<()> {
+        for page in &self.pages {
+            if let Some(controls) = page.controls.as_ref() {
+                validate_winaudio_controls_in(controls, &page.name)?;
+            }
+        }
+        if let Some(global) = self.pages_global.as_ref() {
+            if let Some(controls) = global.controls.as_ref() {
+                validate_winaudio_controls_in(controls, "<global>")?;
+            }
+        }
         Ok(())
     }
 
@@ -778,6 +801,99 @@ impl AppConfig {
 
         Ok(())
     }
+}
+
+/// Driver name that owns Windows audio session control. Duplicated here
+/// (and kept in sync with `drivers::winaudio::DRIVER_NAME`) so the lib
+/// crate can validate session-target YAML without depending on the bin
+/// crate's `drivers` module.
+const WINAUDIO_DRIVER_NAME: &str = "winaudio";
+
+/// Actions on `app: "winaudio"` that consume a session target as their
+/// first param. Used by `validate_winaudio_session_targets` so config-load
+/// rejects typos like `"pined:1"` early (#38).
+const WINAUDIO_SESSION_ACTIONS: &[&str] = &["session_volume", "session_mute"];
+
+/// Validate the session-target param of every winaudio session-action
+/// mapping in `controls`. Errors carry the page/control context.
+fn validate_winaudio_controls_in(
+    controls: &HashMap<String, ControlMapping>,
+    page_name: &str,
+) -> Result<()> {
+    for (control_id, mapping) in controls {
+        if mapping.app != WINAUDIO_DRIVER_NAME {
+            continue;
+        }
+        let Some(action) = mapping.action.as_deref() else {
+            continue;
+        };
+        if !WINAUDIO_SESSION_ACTIONS.contains(&action) {
+            continue;
+        }
+        let params = mapping.params.as_deref().unwrap_or(&[]);
+        parse_winaudio_session_target_str(params).map_err(|e| {
+            anyhow::anyhow!(
+                "page '{}' control '{}' (winaudio.{}): {}",
+                page_name,
+                control_id,
+                action,
+                e
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Lightweight mirror of `drivers::winaudio::actions::parse_session_target`
+/// for use at config-validation time (lib-crate, no access to `drivers`).
+/// Keep semantics in sync with the runtime parser — both must accept the
+/// same surface and reject the same typos.
+fn parse_winaudio_session_target_str(params: &[serde_json::Value]) -> Result<()> {
+    let raw = params
+        .first()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "session action requires a target parameter (auto, pinned:N or discovered:N)"
+            )
+        })?
+        .as_str()
+        .ok_or_else(|| {
+            anyhow::anyhow!("session target must be a string (auto, pinned:N or discovered:N)")
+        })?;
+
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("auto") {
+        return Ok(());
+    }
+
+    let (kind, idx) = trimmed
+        .split_once(':')
+        .ok_or_else(|| anyhow::anyhow!("session target '{}' missing ':' separator", raw))?;
+
+    let n: u8 = idx
+        .trim()
+        .parse()
+        .map_err(|_| anyhow::anyhow!("session target '{}': index '{}' is not a u8", raw, idx))?;
+
+    match kind.trim() {
+        "pinned" => {
+            if !(1..=8).contains(&n) {
+                return Err(anyhow::anyhow!("pinned slot {} must be in 1..=8", n));
+            }
+        },
+        "discovered" => {
+            if n >= 8 {
+                return Err(anyhow::anyhow!("discovered slot {} must be < 8", n));
+            }
+        },
+        other => {
+            return Err(anyhow::anyhow!(
+                "unknown session target kind '{}': expected 'auto', 'pinned' or 'discovered'",
+                other
+            ));
+        },
+    }
+    Ok(())
 }
 
 // Default value functions
@@ -970,5 +1086,110 @@ mod tests {
         cfg.pages[0].controls = Some(controls);
 
         assert!(cfg.references_app("qlc"));
+    }
+
+    // -- #38 — winaudio session-target validation at config-load -------------
+
+    fn winaudio_control(action: &str, param: serde_json::Value) -> ControlMapping {
+        ControlMapping {
+            app: "winaudio".into(),
+            action: Some(action.into()),
+            params: Some(vec![param]),
+            midi: None,
+            indicator: None,
+            overlay: None,
+        }
+    }
+
+    fn cfg_with_winaudio_control(action: &str, param: serde_json::Value) -> AppConfig {
+        let mut cfg = empty_config();
+        let mut controls = HashMap::new();
+        controls.insert("fader1".into(), winaudio_control(action, param));
+        cfg.pages.push(PageConfig {
+            name: "WinAudio".into(),
+            controls: Some(controls),
+            ..PageConfig::default()
+        });
+        cfg
+    }
+
+    #[test]
+    fn validate_winaudio_session_target_accepts_valid_params() {
+        for param in [
+            serde_json::json!("pinned:1"),
+            serde_json::json!("pinned:8"),
+            serde_json::json!("discovered:0"),
+            serde_json::json!("discovered:7"),
+            serde_json::json!("auto"),
+            serde_json::json!("AUTO"),
+        ] {
+            let cfg = cfg_with_winaudio_control("session_volume", param.clone());
+            cfg.validate()
+                .unwrap_or_else(|e| panic!("param {param:?} should be valid, got: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_winaudio_session_target_rejects_bad_prefix() {
+        let cfg = cfg_with_winaudio_control("session_volume", serde_json::json!("pined:1"));
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(err.contains("page 'WinAudio'"), "got: {err}");
+        assert!(err.contains("fader1"), "got: {err}");
+        assert!(err.contains("session_volume"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_winaudio_session_target_rejects_out_of_range() {
+        let cfg = cfg_with_winaudio_control("session_mute", serde_json::json!("pinned:9"));
+        assert!(cfg.validate().is_err());
+        let cfg = cfg_with_winaudio_control("session_mute", serde_json::json!("pinned:0"));
+        assert!(cfg.validate().is_err());
+        let cfg = cfg_with_winaudio_control("session_mute", serde_json::json!("discovered:8"));
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_winaudio_session_target_rejects_wrong_type() {
+        // Numeric param where a string is required.
+        let cfg = cfg_with_winaudio_control("session_volume", serde_json::json!(42));
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_winaudio_session_target_ignores_non_session_actions() {
+        // `master_volume` / `master_mute` take no session target — their
+        // params should not be parsed. Even garbage must pass through.
+        let cfg = cfg_with_winaudio_control("master_volume", serde_json::json!("not a target"));
+        cfg.validate().expect("master_volume params not validated");
+    }
+
+    #[test]
+    fn validate_winaudio_session_target_ignores_other_drivers() {
+        // A `voicemeeter` control with a garbage first-param string must
+        // still pass — only winaudio sessions are checked.
+        let mut cfg = empty_config();
+        let mut controls = HashMap::new();
+        controls.insert(
+            "fader1".into(),
+            ControlMapping {
+                app: "voicemeeter".into(),
+                action: Some("session_volume".into()),
+                params: Some(vec![serde_json::json!("pined:1")]),
+                midi: None,
+                indicator: None,
+                overlay: None,
+            },
+        );
+        cfg.midi.apps = Some(vec![MidiAppConfig {
+            name: "voicemeeter".into(),
+            output_port: Some("vm-out".into()),
+            input_port: Some("vm-in".into()),
+        }]);
+        cfg.pages.push(PageConfig {
+            name: "VM".into(),
+            controls: Some(controls),
+            ..PageConfig::default()
+        });
+        cfg.validate().expect("non-winaudio params not validated");
     }
 }

--- a/src/drivers/winaudio/com_handlers.rs
+++ b/src/drivers/winaudio/com_handlers.rs
@@ -1,0 +1,327 @@
+//! Per-command handlers for the COM thread's main loop.
+//!
+//! Extracted from `com_thread.rs` so [`super::com_thread::run_com_loop`]
+//! stays under the project's 500-line file budget and the match arms
+//! become 3-5 lines (CLAUDE.md function-size limits). See #37.
+//!
+//! Every helper takes `Option<&...>` for its endpoint/manager so the
+//! caller can pass the borrowed `Option` straight from the loop without
+//! re-checking. Callbacks emit `AudioEvent`s through the shared
+//! `event_tx`.
+
+#![cfg(target_os = "windows")]
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use tokio::sync::mpsc;
+use tracing::{debug, trace, warn};
+
+use windows::Win32::Media::Audio::IAudioSessionEvents;
+
+use super::com_thread::{AudioCmd, AudioEvent, SessionReg, SESSION_CACHE_TTL};
+use super::master::MasterEndpoint;
+use super::session::{set_session_volume, toggle_session_mute, SessionInfo, SessionManager};
+use super::session_events::SessionEventsCallback;
+
+/// Return a reference to a cached session matching `process_name_lc`,
+/// re-enumerating once if the cache is missing/expired or the name
+/// isn't found (handles the race where a transient session disappeared
+/// after the last refresh). The returned reference borrows from
+/// `sessions_cache`, which is updated in place on a refresh. Returns
+/// `None` if no matching session exists after the refresh.
+fn cached_session<'a>(
+    mgr: &SessionManager,
+    sessions_cache: &'a mut Option<(Instant, Vec<SessionInfo>)>,
+    process_name_lc: &str,
+) -> Option<&'a SessionInfo> {
+    let needs_refresh = match sessions_cache.as_ref() {
+        None => true,
+        Some((ts, sessions)) => {
+            ts.elapsed() > SESSION_CACHE_TTL
+                || super::mapping::find_session(sessions, process_name_lc).is_none()
+        },
+    };
+    if needs_refresh {
+        match mgr.enumerate() {
+            Ok(sessions) => {
+                *sessions_cache = Some((Instant::now(), sessions));
+            },
+            Err(e) => {
+                warn!("session enumerate failed (cache refresh): {}", e);
+                return None;
+            },
+        }
+    }
+    let sessions = &sessions_cache.as_ref()?.1;
+    super::mapping::find_session(sessions, process_name_lc)
+}
+
+/// Apply `scalar` to the cached session matching `process_name_lc`,
+/// refreshing the cache on miss/TTL expiry. See #35.
+pub(super) fn handle_set_session_scalar(
+    mgr: &SessionManager,
+    sessions_cache: &mut Option<(Instant, Vec<SessionInfo>)>,
+    process_name_lc: &str,
+    scalar: f32,
+) {
+    let Some(s) = cached_session(mgr, sessions_cache, process_name_lc) else {
+        trace!(
+            "No active session for '{}'; ignoring volume command",
+            process_name_lc
+        );
+        return;
+    };
+    if let Err(e) = set_session_volume(s, scalar) {
+        warn!(
+            "SetSessionVolume({}, {}) failed: {}",
+            process_name_lc, scalar, e
+        );
+    }
+}
+
+/// Toggle mute on the cached session matching `process_name_lc` and
+/// emit the resulting state. Sessions have no callback equivalent to
+/// `IAudioEndpointVolumeCallback`, so the mute LED would never refresh
+/// unless we push a snapshot here ourselves. See #35.
+pub(super) fn handle_toggle_session_mute(
+    mgr: &SessionManager,
+    sessions_cache: &mut Option<(Instant, Vec<SessionInfo>)>,
+    process_name_lc: &str,
+    event_tx: &mpsc::Sender<AudioEvent>,
+) {
+    let Some(s) = cached_session(mgr, sessions_cache, process_name_lc) else {
+        return;
+    };
+    match toggle_session_mute(s) {
+        Ok(()) => {
+            let scalar = unsafe { s.volume.GetMasterVolume().unwrap_or(0.0) };
+            let mute = unsafe { s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false) };
+            let _ = event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
+                process_name_lc: process_name_lc.to_string(),
+                scalar,
+                mute,
+            });
+        },
+        Err(e) => warn!("ToggleSessionMute({}) failed: {}", process_name_lc, e),
+    }
+}
+
+/// Apply `scalar` to the master endpoint. When the OS volume-change
+/// callback is wired (normal path) the callback fans out the resulting
+/// state; otherwise we emit a synthetic `MasterVolumeChanged` so the
+/// X-Touch stays in sync. See #41.
+pub(super) fn handle_master_scalar(
+    endpoint: Option<&MasterEndpoint>,
+    scalar: f32,
+    callback_active: bool,
+    event_tx: &mpsc::Sender<AudioEvent>,
+) {
+    let Some(ep) = endpoint else {
+        return;
+    };
+    if let Err(e) = ep.set_volume_scalar(scalar) {
+        warn!("set_volume_scalar({}) failed: {}", scalar, e);
+        return;
+    }
+    if !callback_active {
+        let mute = ep.get_mute().unwrap_or(false);
+        let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
+    }
+}
+
+/// Toggle master mute on the endpoint. Same callback-vs-synthetic
+/// emit logic as [`handle_master_scalar`]. See #41.
+pub(super) fn handle_master_mute(
+    endpoint: Option<&MasterEndpoint>,
+    callback_active: bool,
+    event_tx: &mpsc::Sender<AudioEvent>,
+) {
+    let Some(ep) = endpoint else {
+        return;
+    };
+    let cur = ep.get_mute().unwrap_or(false);
+    if let Err(e) = ep.set_mute(!cur) {
+        warn!("set_mute failed: {}", e);
+        return;
+    }
+    if !callback_active {
+        let scalar = ep.get_volume_scalar().unwrap_or(0.0);
+        let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute: !cur });
+    }
+}
+
+/// Read the current master state and emit it as a `MasterVolumeChanged`
+/// event. Used to re-sync the X-Touch on page activation (the OS
+/// callback only fires on actual *changes*).
+pub(super) fn handle_refresh_master(
+    endpoint: Option<&MasterEndpoint>,
+    event_tx: &mpsc::Sender<AudioEvent>,
+) {
+    let Some(ep) = endpoint else {
+        return;
+    };
+    if let (Ok(scalar), Ok(mute)) = (ep.get_volume_scalar(), ep.get_mute()) {
+        let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
+    }
+}
+
+/// Re-enumerate active sessions, register per-session events on any new
+/// ones, and refresh the cache used by hot-path `Set*` / `Toggle*` arms.
+pub(super) fn handle_refresh_sessions(
+    mgr: Option<&SessionManager>,
+    event_tx: &mpsc::Sender<AudioEvent>,
+    cmd_tx: &mpsc::Sender<AudioCmd>,
+    session_regs: &mut HashMap<u32, SessionReg>,
+    sessions_cache: &mut Option<(Instant, Vec<SessionInfo>)>,
+) {
+    let Some(mgr) = mgr else {
+        return;
+    };
+    let sessions = register_session_events_for_all(mgr, event_tx, cmd_tx, session_regs);
+    *sessions_cache = Some((Instant::now(), sessions));
+}
+
+/// Enumerate sessions, populate the cache, and return their lowercase
+/// process names. Used by the `EnumerateSessions` oneshot reply.
+pub(super) fn handle_enumerate_sessions(
+    mgr: Option<&SessionManager>,
+    sessions_cache: &mut Option<(Instant, Vec<SessionInfo>)>,
+) -> Vec<String> {
+    mgr.and_then(|m| m.enumerate().ok())
+        .map(|sessions| {
+            let names = sessions
+                .iter()
+                .map(|s| s.process_name.clone())
+                .filter(|n| !n.is_empty())
+                .collect::<Vec<_>>();
+            *sessions_cache = Some((Instant::now(), sessions));
+            names
+        })
+        .unwrap_or_default()
+}
+
+/// Enumerate all sessions, register an `IAudioSessionEvents` callback on
+/// each new one, push a `SessionVolumeSnapshot` so the consumer sees
+/// every session's current state immediately, then emit a single
+/// `ActiveSessionsChanged` summary at the end. Re-running this is safe:
+/// already-registered sessions are skipped (looked up by PID), and PIDs
+/// that have disappeared since the previous pass are unregistered to
+/// prevent the `session_regs` map from growing unbounded.
+///
+/// Returns the freshly enumerated `SessionInfo`s so callers can populate
+/// the cache used by hot-path `Set*` / `Toggle*` arms (#35).
+pub(super) fn register_session_events_for_all(
+    mgr: &SessionManager,
+    event_tx: &mpsc::Sender<AudioEvent>,
+    cmd_tx: &mpsc::Sender<AudioCmd>,
+    session_regs: &mut HashMap<u32, SessionReg>,
+) -> Vec<SessionInfo> {
+    let sessions = match mgr.enumerate() {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("session enumerate failed: {}", e);
+            return Vec::new();
+        },
+    };
+
+    let mut active_names: Vec<String> = Vec::with_capacity(sessions.len());
+    let mut active_pids: std::collections::HashSet<u32> =
+        std::collections::HashSet::with_capacity(sessions.len());
+
+    for s in &sessions {
+        if s.process_name.is_empty() {
+            continue;
+        }
+        active_pids.insert(s.pid);
+        if !active_names.contains(&s.process_name) {
+            active_names.push(s.process_name.clone());
+        }
+
+        // Always push the current state — the consumer is idempotent and
+        // this is what catches sessions whose volume changed while we
+        // weren't subscribed (or before our callback was registered).
+        let scalar = unsafe { s.volume.GetMasterVolume().unwrap_or(0.0) };
+        let mute = unsafe { s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false) };
+        let _ = event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
+            process_name_lc: s.process_name.clone(),
+            scalar,
+            mute,
+        });
+
+        register_session_events_for_one(s, event_tx, cmd_tx, session_regs);
+    }
+
+    purge_stale_session_regs(session_regs, &active_pids);
+
+    // Atomic "active set" marker — the consumer uses this to swap its
+    // active-session view in one go.
+    let _ = event_tx.try_send(AudioEvent::ActiveSessionsChanged {
+        names_lc: active_names,
+    });
+
+    sessions
+}
+
+/// Register an `IAudioSessionEvents` callback on `s` if no callback is
+/// already registered for its PID. No-op on re-register.
+fn register_session_events_for_one(
+    s: &SessionInfo,
+    event_tx: &mpsc::Sender<AudioEvent>,
+    cmd_tx: &mpsc::Sender<AudioCmd>,
+    session_regs: &mut HashMap<u32, SessionReg>,
+) {
+    if session_regs.contains_key(&s.pid) {
+        return;
+    }
+    let cb_impl =
+        SessionEventsCallback::new(event_tx.clone(), cmd_tx.clone(), s.process_name.clone());
+    let events: IAudioSessionEvents = cb_impl.into();
+    // Cloning a COM interface bumps the refcount; the registration
+    // map then holds an independent reference to the same control
+    // object that we also keep in the cache.
+    match unsafe { s.control.RegisterAudioSessionNotification(&events) } {
+        Ok(()) => {
+            debug!(
+                "RegisterAudioSessionNotification(pid={}, {}) succeeded",
+                s.pid, s.process_name
+            );
+            session_regs.insert(
+                s.pid,
+                SessionReg {
+                    control: s.control.clone(),
+                    events,
+                },
+            );
+        },
+        Err(e) => warn!(
+            "RegisterAudioSessionNotification(pid={}, {}) failed: {:?}",
+            s.pid, s.process_name, e
+        ),
+    }
+}
+
+/// Unregister callbacks for PIDs that have disappeared since the last
+/// pass. Prevents the map from growing unboundedly across long-lived
+/// runs where many short-lived audio sources come and go.
+fn purge_stale_session_regs(
+    session_regs: &mut HashMap<u32, SessionReg>,
+    active_pids: &std::collections::HashSet<u32>,
+) {
+    let stale_pids: Vec<u32> = session_regs
+        .keys()
+        .filter(|pid| !active_pids.contains(pid))
+        .copied()
+        .collect();
+    for pid in stale_pids {
+        if let Some(reg) = session_regs.remove(&pid) {
+            if let Err(e) = unsafe { reg.control.UnregisterAudioSessionNotification(&reg.events) } {
+                trace!(
+                    "UnregisterAudioSessionNotification(pid={}) on stale session failed: {:?}",
+                    pid,
+                    e
+                );
+            }
+        }
+    }
+}

--- a/src/drivers/winaudio/com_thread.rs
+++ b/src/drivers/winaudio/com_thread.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolumeCallback;
 use windows::Win32::Media::Audio::{
@@ -22,15 +22,20 @@ use windows::Win32::Media::Audio::{
 use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
 
 use super::callback::EndpointVolumeCallback;
+use super::com_handlers::{
+    handle_enumerate_sessions, handle_master_mute, handle_master_scalar, handle_refresh_master,
+    handle_refresh_sessions, handle_set_session_scalar, handle_toggle_session_mute,
+    register_session_events_for_all,
+};
 use super::master::MasterEndpoint;
-use super::session::{set_session_volume, toggle_session_mute, SessionInfo, SessionManager};
-use super::session_events::{NewSessionCallback, SessionEventsCallback};
+use super::session::{SessionInfo, SessionManager};
+use super::session_events::NewSessionCallback;
 
 /// Max age for the cached session enumeration before a hot-path access
 /// triggers a fresh re-enumerate. `OnSessionCreated` /
 /// `OnStateChanged(Expired)` proactively invalidate the cache, so this
 /// is a safety net for transient sessions that slipped between events.
-const SESSION_CACHE_TTL: Duration = Duration::from_secs(2);
+pub(super) const SESSION_CACHE_TTL: Duration = Duration::from_secs(2);
 
 #[derive(Debug)]
 pub enum AudioCmd {
@@ -187,9 +192,9 @@ impl ComThreadHandle {
 /// Per-PID registration: we keep the `IAudioSessionControl2` so we can
 /// unregister at shutdown, and the `IAudioSessionEvents` interface so the
 /// audio engine has a live reference to call back into.
-struct SessionReg {
-    control: IAudioSessionControl2,
-    events: IAudioSessionEvents,
+pub(super) struct SessionReg {
+    pub(super) control: IAudioSessionControl2,
+    pub(super) events: IAudioSessionEvents,
 }
 
 fn run_com_loop(
@@ -294,45 +299,22 @@ fn run_com_loop(
     while let Some(cmd) = cmd_rx.blocking_recv() {
         match cmd {
             AudioCmd::SetMasterScalar(scalar) => {
-                if let Some(ep) = endpoint.as_ref() {
-                    if let Err(e) = ep.set_volume_scalar(scalar) {
-                        warn!("set_volume_scalar({}) failed: {}", scalar, e);
-                    } else if !master_callback_active {
-                        // Callback registration failed at init — fall back
-                        // to the legacy synthetic emit so the X-Touch stays
-                        // in sync. Normal path skips this (see #41).
-                        let mute = ep.get_mute().unwrap_or(false);
-                        let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
-                    }
-                }
+                handle_master_scalar(endpoint.as_ref(), scalar, master_callback_active, &event_tx);
             },
             AudioCmd::ToggleMasterMute => {
-                if let Some(ep) = endpoint.as_ref() {
-                    let cur = ep.get_mute().unwrap_or(false);
-                    if let Err(e) = ep.set_mute(!cur) {
-                        warn!("set_mute failed: {}", e);
-                    } else if !master_callback_active {
-                        // See SetMasterScalar — same fallback when the OS
-                        // callback isn't wired.
-                        let scalar = ep.get_volume_scalar().unwrap_or(0.0);
-                        let _ = event_tx
-                            .try_send(AudioEvent::MasterVolumeChanged { scalar, mute: !cur });
-                    }
-                }
+                handle_master_mute(endpoint.as_ref(), master_callback_active, &event_tx);
             },
             AudioCmd::RefreshMaster => {
-                if let Some(ep) = endpoint.as_ref() {
-                    if let (Ok(scalar), Ok(mute)) = (ep.get_volume_scalar(), ep.get_mute()) {
-                        let _ = event_tx.try_send(AudioEvent::MasterVolumeChanged { scalar, mute });
-                    }
-                }
+                handle_refresh_master(endpoint.as_ref(), &event_tx);
             },
             AudioCmd::RefreshSessions => {
-                if let Some(mgr) = session_mgr.as_ref() {
-                    let sessions =
-                        register_session_events_for_all(mgr, &event_tx, &cmd_tx, &mut session_regs);
-                    sessions_cache = Some((Instant::now(), sessions));
-                }
+                handle_refresh_sessions(
+                    session_mgr.as_ref(),
+                    &event_tx,
+                    &cmd_tx,
+                    &mut session_regs,
+                    &mut sessions_cache,
+                );
             },
             AudioCmd::SetSessionScalar {
                 process_name_lc,
@@ -353,19 +335,7 @@ fn run_com_loop(
                 }
             },
             AudioCmd::EnumerateSessions { reply } => {
-                let names = session_mgr
-                    .as_ref()
-                    .and_then(|m| m.enumerate().ok())
-                    .map(|sessions| {
-                        let names = sessions
-                            .iter()
-                            .map(|s| s.process_name.clone())
-                            .filter(|n| !n.is_empty())
-                            .collect::<Vec<_>>();
-                        sessions_cache = Some((Instant::now(), sessions));
-                        names
-                    })
-                    .unwrap_or_default();
+                let names = handle_enumerate_sessions(session_mgr.as_ref(), &mut sessions_cache);
                 let _ = reply.send(names);
             },
             AudioCmd::Shutdown => {
@@ -403,196 +373,4 @@ fn run_com_loop(
     drop(endpoint);
     drop(session_mgr);
     unsafe { CoUninitialize() };
-}
-
-/// Enumerate all sessions, register an `IAudioSessionEvents` callback on
-/// each new one, push a `SessionVolumeSnapshot` so the consumer sees
-/// every session's current state immediately, then emit a single
-/// `ActiveSessionsChanged` summary at the end. Re-running this is safe:
-/// already-registered sessions are skipped (looked up by PID), and PIDs
-/// that have disappeared since the previous pass are unregistered to
-/// prevent the `session_regs` map from growing unbounded.
-///
-/// Returns the freshly enumerated `SessionInfo`s so callers can populate
-/// the cache used by hot-path `Set*` / `Toggle*` arms (#35).
-fn register_session_events_for_all(
-    mgr: &SessionManager,
-    event_tx: &mpsc::Sender<AudioEvent>,
-    cmd_tx: &mpsc::Sender<AudioCmd>,
-    session_regs: &mut HashMap<u32, SessionReg>,
-) -> Vec<SessionInfo> {
-    let sessions = match mgr.enumerate() {
-        Ok(s) => s,
-        Err(e) => {
-            warn!("session enumerate failed: {}", e);
-            return Vec::new();
-        },
-    };
-
-    let mut active_names: Vec<String> = Vec::with_capacity(sessions.len());
-    let mut active_pids: std::collections::HashSet<u32> =
-        std::collections::HashSet::with_capacity(sessions.len());
-
-    for s in &sessions {
-        if s.process_name.is_empty() {
-            continue;
-        }
-        active_pids.insert(s.pid);
-        if !active_names.contains(&s.process_name) {
-            active_names.push(s.process_name.clone());
-        }
-
-        // Always push the current state — the consumer is idempotent and
-        // this is what catches sessions whose volume changed while we
-        // weren't subscribed (or before our callback was registered).
-        let scalar = unsafe { s.volume.GetMasterVolume().unwrap_or(0.0) };
-        let mute = unsafe { s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false) };
-        let _ = event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
-            process_name_lc: s.process_name.clone(),
-            scalar,
-            mute,
-        });
-
-        // Skip if we already have an events callback registered for this PID.
-        if session_regs.contains_key(&s.pid) {
-            continue;
-        }
-
-        let cb_impl =
-            SessionEventsCallback::new(event_tx.clone(), cmd_tx.clone(), s.process_name.clone());
-        let events: IAudioSessionEvents = cb_impl.into();
-        // Cloning a COM interface bumps the refcount; the registration
-        // map then holds an independent reference to the same control
-        // object that we also keep in the cache.
-        match unsafe { s.control.RegisterAudioSessionNotification(&events) } {
-            Ok(()) => {
-                debug!(
-                    "RegisterAudioSessionNotification(pid={}, {}) succeeded",
-                    s.pid, s.process_name
-                );
-                session_regs.insert(
-                    s.pid,
-                    SessionReg {
-                        control: s.control.clone(),
-                        events,
-                    },
-                );
-            },
-            Err(e) => warn!(
-                "RegisterAudioSessionNotification(pid={}, {}) failed: {:?}",
-                s.pid, s.process_name, e
-            ),
-        }
-    }
-
-    // Unregister callbacks for PIDs that have disappeared since the last
-    // pass. Prevents the map from growing unboundedly across long-lived
-    // sessions where many short-lived audio sources come and go.
-    let stale_pids: Vec<u32> = session_regs
-        .keys()
-        .filter(|pid| !active_pids.contains(pid))
-        .copied()
-        .collect();
-    for pid in stale_pids {
-        if let Some(reg) = session_regs.remove(&pid) {
-            if let Err(e) = unsafe { reg.control.UnregisterAudioSessionNotification(&reg.events) } {
-                trace!(
-                    "UnregisterAudioSessionNotification(pid={}) on stale session failed: {:?}",
-                    pid,
-                    e
-                );
-            }
-        }
-    }
-
-    // Atomic "active set" marker — the consumer uses this to swap its
-    // active-session view in one go.
-    let _ = event_tx.try_send(AudioEvent::ActiveSessionsChanged {
-        names_lc: active_names,
-    });
-
-    sessions
-}
-
-/// Return a reference to a cached session matching `process_name_lc`,
-/// re-enumerating once if the cache is missing/expired or the name
-/// isn't found (handles the race where a transient session disappeared
-/// after the last refresh). The returned reference borrows from
-/// `sessions_cache`, which is updated in place on a refresh. Returns
-/// `None` if no matching session exists after the refresh.
-fn cached_session<'a>(
-    mgr: &SessionManager,
-    sessions_cache: &'a mut Option<(Instant, Vec<SessionInfo>)>,
-    process_name_lc: &str,
-) -> Option<&'a SessionInfo> {
-    let needs_refresh = match sessions_cache.as_ref() {
-        None => true,
-        Some((ts, sessions)) => {
-            ts.elapsed() > SESSION_CACHE_TTL
-                || super::mapping::find_session(sessions, process_name_lc).is_none()
-        },
-    };
-    if needs_refresh {
-        match mgr.enumerate() {
-            Ok(sessions) => {
-                *sessions_cache = Some((Instant::now(), sessions));
-            },
-            Err(e) => {
-                warn!("session enumerate failed (cache refresh): {}", e);
-                return None;
-            },
-        }
-    }
-    let sessions = &sessions_cache.as_ref()?.1;
-    super::mapping::find_session(sessions, process_name_lc)
-}
-
-/// Apply `scalar` to the cached session matching `process_name_lc`,
-/// refreshing the cache on miss/TTL expiry. See #35.
-fn handle_set_session_scalar(
-    mgr: &SessionManager,
-    sessions_cache: &mut Option<(Instant, Vec<SessionInfo>)>,
-    process_name_lc: &str,
-    scalar: f32,
-) {
-    let Some(s) = cached_session(mgr, sessions_cache, process_name_lc) else {
-        trace!(
-            "No active session for '{}'; ignoring volume command",
-            process_name_lc
-        );
-        return;
-    };
-    if let Err(e) = set_session_volume(s, scalar) {
-        warn!(
-            "SetSessionVolume({}, {}) failed: {}",
-            process_name_lc, scalar, e
-        );
-    }
-}
-
-/// Toggle mute on the cached session matching `process_name_lc` and
-/// emit the resulting state. Sessions have no callback equivalent to
-/// `IAudioEndpointVolumeCallback`, so the mute LED would never refresh
-/// unless we push a snapshot here ourselves. See #35.
-fn handle_toggle_session_mute(
-    mgr: &SessionManager,
-    sessions_cache: &mut Option<(Instant, Vec<SessionInfo>)>,
-    process_name_lc: &str,
-    event_tx: &mpsc::Sender<AudioEvent>,
-) {
-    let Some(s) = cached_session(mgr, sessions_cache, process_name_lc) else {
-        return;
-    };
-    match toggle_session_mute(s) {
-        Ok(()) => {
-            let scalar = unsafe { s.volume.GetMasterVolume().unwrap_or(0.0) };
-            let mute = unsafe { s.volume.GetMute().map(|b| b.as_bool()).unwrap_or(false) };
-            let _ = event_tx.try_send(AudioEvent::SessionVolumeSnapshot {
-                process_name_lc: process_name_lc.to_string(),
-                scalar,
-                mute,
-            });
-        },
-        Err(e) => warn!("ToggleSessionMute({}) failed: {}", process_name_lc, e),
-    }
 }

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -14,6 +14,8 @@ mod actions;
 mod callback;
 mod catalog;
 #[cfg(target_os = "windows")]
+mod com_handlers;
+#[cfg(target_os = "windows")]
 mod com_thread;
 mod mapping;
 #[cfg(target_os = "windows")]

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -200,9 +200,16 @@ impl Driver for WinAudioDriver {
                     // (auto-detected — see `page_uses_winaudio`).
                     self.spawn_page_watcher().await;
 
-                    // Initial state push, after a short delay so the active
-                    // page settles before we emit; the router's page filter
-                    // would otherwise drop the feedback.
+                    // Initial state push, gated on the `ProfileLoaded`
+                    // live event so the active page is fully settled
+                    // before we emit (the router's page filter would
+                    // otherwise drop the feedback). Replaces the legacy
+                    // 800 ms sleep (#36). 2 s timeout is a safety net
+                    // for the no-subscriber edge case.
+                    let live_rx = match self.router.read().await.as_ref() {
+                        Some(r) => r.live_tx_snapshot().await.map(|tx| tx.subscribe()),
+                        None => None,
+                    };
                     let com = self.com.clone();
                     let cfg = self.config.clone();
                     let pinned_lc_cache = self.pinned_lc_cache.clone();
@@ -210,11 +217,11 @@ impl Driver for WinAudioDriver {
                     let router = self.router.clone();
                     let led_tx = self.led_tx.clone();
                     tokio::spawn(async move {
-                        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+                        wait_for_profile_loaded(live_rx).await;
                         refresh_full_state(&com, &pinned_lc_cache, &disc).await;
-                        // If the active page is already the winaudio
-                        // page at startup (no PageChanged event will
-                        // fire to wake the watcher), render the LCD now.
+                        // If the active page already maps winaudio at
+                        // startup (no PageChanged event will fire to wake
+                        // the watcher), render the LCD now.
                         render_lcd_if_active(&router, &led_tx, &cfg, &pinned_lc_cache, &disc).await;
                     });
                 },
@@ -504,6 +511,35 @@ async fn refresh_full_state(
 /// reading.
 fn normalize_fader_value(v: f64) -> f32 {
     ((v / 16383.0) as f32).clamp(0.0, 1.0)
+}
+
+/// Block until the startup profile is marked loaded (config parsed,
+/// router wired, drivers registered) — or until the 2 s safety timeout
+/// elapses. Replaces the legacy 800 ms post-init sleep (#36).
+///
+/// If `live_rx` is `None` (live bus not wired in tests, unusual prod
+/// path), fall straight through.
+async fn wait_for_profile_loaded(
+    live_rx: Option<tokio::sync::broadcast::Receiver<crate::event_bus::LiveEvent>>,
+) {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+    let Some(mut rx) = live_rx else {
+        debug!("WinAudio init: live bus unavailable, skipping ProfileLoaded await");
+        return;
+    };
+    let fut = async {
+        while let Ok(event) = rx.recv().await {
+            if matches!(event, crate::event_bus::LiveEvent::ProfileLoaded { .. }) {
+                return;
+            }
+        }
+    };
+    if tokio::time::timeout(TIMEOUT, fut).await.is_err() {
+        debug!(
+            "WinAudio init: ProfileLoaded not received within {:?}, proceeding with refresh anyway",
+            TIMEOUT
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -41,9 +41,30 @@ pub use actions::{parse_session_target, SessionTarget};
 /// Driver name used for `app: "winaudio"` in YAML control mappings.
 pub const DRIVER_NAME: &str = "winaudio";
 
-/// YAML page name on which the dynamic LCD render is applied. Hard-coded
-/// for now; documented hors-scope in the plan.
-const WINAUDIO_PAGE_NAME: &str = "Windows Audio";
+/// True if at least one control on `page` binds `app: "winaudio"`. Used to
+/// decide whether a page is "winaudio-eligible" for state refresh and
+/// dynamic LCD rendering. Auto-detected so the YAML page name is no
+/// longer load-bearing — renaming `"Windows Audio"` to anything else
+/// keeps the driver wired (#39).
+fn page_uses_winaudio(page: &PageConfig) -> bool {
+    page.controls
+        .as_ref()
+        .is_some_and(|c| c.values().any(|m| m.app == DRIVER_NAME))
+}
+
+/// True if the page at `index` in the router's current config uses the
+/// winaudio driver. Lock-friendly: takes a single short read on
+/// `Router::config`.
+async fn page_eligible_at_index(
+    router_arc: &Arc<RwLock<Option<Arc<crate::router::Router>>>>,
+    index: usize,
+) -> bool {
+    let Some(router) = router_arc.read().await.clone() else {
+        return false;
+    };
+    let cfg = router.config.read().await;
+    cfg.pages.get(index).is_some_and(page_uses_winaudio)
+}
 
 pub struct WinAudioDriver {
     config: Arc<RwLock<WinAudioConfig>>,
@@ -175,7 +196,8 @@ impl Driver for WinAudioDriver {
                     *self.com.write().await = Some(handle);
 
                     // Subscribe to page changes so we re-emit master state
-                    // every time "Windows Audio" becomes active.
+                    // every time a winaudio-eligible page becomes active
+                    // (auto-detected — see `page_uses_winaudio`).
                     self.spawn_page_watcher().await;
 
                     // Initial state push, after a short delay so the active
@@ -383,11 +405,13 @@ impl WinAudioDriver {
     }
 
     /// Spawn a background task that re-emits master + per-session state
-    /// whenever the "Windows Audio" page becomes active. Necessary
-    /// because the `IAudioEndpointVolumeCallback` only fires on actual
-    /// volume *changes*, never on page activation — so without this
-    /// the X-Touch fader stays at its old position the first time
-    /// the user switches to the Windows Audio page.
+    /// whenever a winaudio-eligible page becomes active (auto-detected
+    /// via [`page_uses_winaudio`] — no hardcoded page name).
+    ///
+    /// Necessary because `IAudioEndpointVolumeCallback` only fires on
+    /// actual volume *changes*, never on page activation — so without
+    /// this the X-Touch fader stays at its old position the first time
+    /// the user switches to a winaudio page.
     async fn spawn_page_watcher(&self) {
         let router_arc = self.router.read().await.clone();
         let Some(router) = router_arc else {
@@ -408,23 +432,25 @@ impl WinAudioDriver {
         let led_tx = self.led_tx.clone();
         tokio::spawn(async move {
             while let Ok(event) = rx.recv().await {
-                if let crate::event_bus::LiveEvent::PageChanged { name, .. } = event {
-                    if name == WINAUDIO_PAGE_NAME {
-                        debug!("WinAudio: page activated, refreshing master + sessions");
-                        #[cfg(target_os = "windows")]
-                        {
-                            refresh_full_state(&com, &pinned_lc_cache, &discovery).await;
-                        }
-                        render_lcd_if_active(
-                            &router_for_render,
-                            &led_tx,
-                            &config,
-                            &pinned_lc_cache,
-                            &discovery,
-                        )
-                        .await;
-                    }
+                let crate::event_bus::LiveEvent::PageChanged { index, .. } = event else {
+                    continue;
+                };
+                if !page_eligible_at_index(&router_for_render, index).await {
+                    continue;
                 }
+                debug!("WinAudio: page activated, refreshing master + sessions");
+                #[cfg(target_os = "windows")]
+                {
+                    refresh_full_state(&com, &pinned_lc_cache, &discovery).await;
+                }
+                render_lcd_if_active(
+                    &router_for_render,
+                    &led_tx,
+                    &config,
+                    &pinned_lc_cache,
+                    &discovery,
+                )
+                .await;
             }
         });
     }
@@ -445,7 +471,7 @@ impl WinAudioDriver {
 
 /// Re-enumerate discovery so newly opened apps land in the FIFO order,
 /// then trigger master + per-session feedback emission. Used both at
-/// startup and on every "Windows Audio" page activation.
+/// startup and on every winaudio-eligible page activation.
 #[cfg(target_os = "windows")]
 async fn refresh_full_state(
     com: &Arc<RwLock<Option<com_thread::ComThreadHandle>>>,
@@ -862,7 +888,7 @@ async fn render_lcd_if_active(
     let Some(page) = router_arc.get_active_page().await else {
         return;
     };
-    if page.name != WINAUDIO_PAGE_NAME {
+    if !page_uses_winaudio(&page) {
         return;
     }
     let Some(tx) = led_tx.read().await.clone() else {

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -33,6 +33,15 @@ pub enum LiveEvent {
     ConfigReloaded { ts: u64 },
     /// The active page changed (X-Touch buttons, REPL, or editor request).
     PageChanged { index: usize, name: String, ts: u64 },
+    /// The startup profile finished loading: config parsed + router built +
+    /// drivers registered. Emitted exactly once per process. Used by
+    /// late-starting drivers (winaudio) to know when the active page is
+    /// settled and refresh feedback won't be dropped by the page filter.
+    ProfileLoaded {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        profile_name: Option<String>,
+        ts: u64,
+    },
 }
 
 #[derive(Clone, Debug, Serialize)]


### PR DESCRIPTION
## Summary
- Closes #39: auto-detect winaudio pages by inspecting `app: "winaudio"` controls (zero-config; `WINAUDIO_PAGE_NAME` literal removed).
- Closes #36: replace the 800 ms post-init sleep with an `await` on `LiveEvent::ProfileLoaded` (added to `event_bus`, emitted from `app::run_app` after drivers are registered; 2 s timeout safety net).
- Closes #38: validate winaudio session-target params (e.g. `pinned:1`, `discovered:3`) at config-load time; typos now error at startup instead of at button-press, with page + control context in the message.
- Closes #37: extract per-arm helpers (`handle_master_scalar`, `handle_master_mute`, `handle_refresh_master`, `handle_refresh_sessions`, `handle_enumerate_sessions`) into a new `com_handlers` submodule. `com_thread.rs` drops from 599 to 378 LOC; the match block is now 49 lines of 3-5-line arms.

## Why
Follow-up to PR-W1. Removes the last magic constants and timing hacks from the winaudio driver. Surfaces YAML config errors early. Keeps `com_thread.rs` under the project's 500-LOC file budget.

## Test plan
- [x] ``cargo build`` + ``cargo build --release`` clean
- [x] ``cargo test`` — 242 tests passing (27 lib + 203 bin + 12 integ)
- [x] ``cargo clippy --all-targets`` — no new warnings in touched files (the duplicated-cfg warning on the new ``com_handlers.rs`` matches the existing pattern across all 5 other winaudio submodules)
- [x] Unit tests for #38: valid (pinned/discovered/auto/case), invalid prefix, out-of-range, wrong JSON type, scoping (non-session winaudio actions and other drivers untouched)
- [ ] Hardware: start on a winaudio page -> state appears immediately (no 800 ms delay)
- [ ] Hardware: start on non-winaudio page, switch to it -> state appears
- [ ] Config: introduce a typo in ``params: ["pined:1"]`` -> startup fails with ``page '<name>' control '<id>' (winaudio.session_volume): unknown session target kind 'pined'``

Note on ``WINAUDIO_DRIVER_NAME`` duplication: the lib crate (``src/config/``) cannot depend on the bin crate's ``drivers::winaudio``, so the validation re-implements ``parse_session_target`` as ``parse_winaudio_session_target_str`` with a sync-comment. Tests exercise both paths.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)