### PR TITLE
chore: clippy follow-up — cleanup remaining warnings in stabilized files

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -540,7 +540,10 @@ impl AppConfig {
         Ok(config)
     }
 
-    /// Save configuration to file
+    /// Save configuration to file. Currently uncalled; kept as the
+    /// canonical YAML serializer for the upcoming editor write path
+    /// (the legacy editor goes through `config::profiles` instead).
+    #[allow(dead_code)]
     pub async fn save(&self, path: &str) -> Result<()> {
         let yaml = serde_yaml::to_string(self).context("Failed to serialize config to YAML")?;
 

--- a/src/drivers/winaudio/callback.rs
+++ b/src/drivers/winaudio/callback.rs
@@ -5,8 +5,9 @@
 //! gateway and drive the motorized fader / mute LED. Runs on the OS
 //! audio thread, so it must be non-blocking — `try_send` and drop on
 //! full.
-
-#![cfg(target_os = "windows")]
+//!
+//! Module is `#[cfg(target_os = "windows")]`-gated at its parent declaration
+//! in `mod.rs`.
 
 use tokio::sync::mpsc;
 use tracing::trace;

--- a/src/drivers/winaudio/com_handlers.rs
+++ b/src/drivers/winaudio/com_handlers.rs
@@ -8,8 +8,9 @@
 //! caller can pass the borrowed `Option` straight from the loop without
 //! re-checking. Callbacks emit `AudioEvent`s through the shared
 //! `event_tx`.
-
-#![cfg(target_os = "windows")]
+//!
+//! Module is `#[cfg(target_os = "windows")]`-gated at its parent declaration
+//! in `mod.rs`.
 
 use std::collections::HashMap;
 use std::time::Instant;

--- a/src/drivers/winaudio/com_thread.rs
+++ b/src/drivers/winaudio/com_thread.rs
@@ -3,8 +3,9 @@
 //! Public API is the [`ComThreadHandle`]: spawn the thread, send commands
 //! over an `mpsc` channel, and shut it down on driver teardown. All COM
 //! interface usage is confined to this thread.
-
-#![cfg(target_os = "windows")]
+//!
+//! Module is `#[cfg(target_os = "windows")]`-gated at its parent declaration
+//! in `mod.rs`.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/drivers/winaudio/mapping.rs
+++ b/src/drivers/winaudio/mapping.rs
@@ -29,6 +29,9 @@ use super::session::SessionInfo;
 /// `discovered_target` / `derive_label` to avoid an extra Vec allocation.
 /// Kept under `#[cfg(test)]` until a non-test caller materializes.
 #[cfg(test)]
+#[allow(dead_code)]
+// `display_name` is part of the planned non-test API surface;
+// currently only `fader` + `process_name` are asserted in tests.
 #[derive(Debug, Clone)]
 pub struct SlotBinding {
     /// 1..=8.

--- a/src/drivers/winaudio/mapping.rs
+++ b/src/drivers/winaudio/mapping.rs
@@ -23,6 +23,12 @@ use crate::config::PinnedApp;
 use super::session::SessionInfo;
 
 /// Output of a single mapping pass: a concrete fader slot binding.
+///
+/// Currently only consumed by `compute_slots` tests — the production LCD
+/// render path resolves per-fader on demand via `pinned_target` /
+/// `discovered_target` / `derive_label` to avoid an extra Vec allocation.
+/// Kept under `#[cfg(test)]` until a non-test caller materializes.
+#[cfg(test)]
 #[derive(Debug, Clone)]
 pub struct SlotBinding {
     /// 1..=8.
@@ -137,6 +143,11 @@ impl DiscoveryState {
 /// process names — owned by the caller (cached on `WinAudioDriver`) so
 /// hot-path callers don't rebuild it per event.
 /// The result has at most 8 entries (one per fader).
+///
+/// Currently only consumed by tests; production code resolves per-fader
+/// on demand to avoid the intermediate Vec. Kept here so the mapping
+/// invariants stay covered by unit tests.
+#[cfg(test)]
 pub fn compute_slots(
     pinned: &[PinnedApp],
     pinned_lc: &HashSet<String>,
@@ -166,14 +177,14 @@ pub fn compute_slots(
         .discovered_order
         .iter()
         .filter(|n| !pinned_lc.contains(*n));
-    for slot_idx in 0..8 {
-        if bindings[slot_idx].is_some() {
+    for (slot_idx, slot) in bindings.iter_mut().enumerate().take(8) {
+        if slot.is_some() {
             continue;
         }
         let Some(name_lc) = discovered_iter.next() else {
             break;
         };
-        bindings[slot_idx] = Some(SlotBinding {
+        *slot = Some(SlotBinding {
             fader: (slot_idx + 1) as u8,
             process_name: Some(name_lc.clone()),
             display_name: derive_label(name_lc),

--- a/src/drivers/winaudio/master.rs
+++ b/src/drivers/winaudio/master.rs
@@ -4,8 +4,9 @@
 //! default audio render endpoint (eRender, eConsole). All methods are
 //! synchronous and must be invoked on a thread that has called
 //! `CoInitializeEx(COINIT_APARTMENTTHREADED)`.
-
-#![cfg(target_os = "windows")]
+//!
+//! Module is `#[cfg(target_os = "windows")]`-gated at its parent declaration
+//! in `mod.rs`.
 
 use anyhow::{Context, Result};
 use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -43,6 +43,12 @@ pub use actions::{parse_session_target, SessionTarget};
 /// Driver name used for `app: "winaudio"` in YAML control mappings.
 pub const DRIVER_NAME: &str = "winaudio";
 
+/// Item pushed onto the unified feedback channel: `(app_name, raw_midi_bytes)`.
+type FeedbackMsg = (String, Vec<u8>);
+
+/// Optional, post-construction-wired sender for the unified feedback channel.
+type FeedbackSender = Arc<RwLock<Option<mpsc::Sender<FeedbackMsg>>>>;
+
 /// True if at least one control on `page` binds `app: "winaudio"`. Used to
 /// decide whether a page is "winaudio-eligible" for state refresh and
 /// dynamic LCD rendering. Auto-detected so the YAML page name is no
@@ -79,14 +85,14 @@ pub struct WinAudioDriver {
     /// Wired post-construction. The COM event consumer task uses this to
     /// inject synthetic `("winaudio", raw_midi)` feedback into the unified
     /// router feedback path.
-    feedback_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<u8>)>>>>,
+    feedback_tx: FeedbackSender,
     /// Stable FIFO of non-pinned process names; never reorders existing entries.
     discovery: Arc<RwLock<mapping::DiscoveryState>>,
     /// Lowercased set of pinned process names. Cached so hot-path
-    /// resolves (`mapping::discovered_target`, `target_for_process`,
-    /// `compute_slots`) read it lock-free instead of rebuilding from
-    /// `config.pinned_apps` per MIDI event. Refreshed by `refresh_pinned_lc`
-    /// on init and on every config-touching path (`sync()`, etc.).
+    /// resolves (`mapping::discovered_target`, `mapping::target_for_process`)
+    /// read it lock-free instead of rebuilding from `config.pinned_apps`
+    /// per MIDI event. Refreshed by `refresh_pinned_lc` on init and on
+    /// every config-touching path (`sync()`, etc.).
     pinned_lc_cache: Arc<ArcSwap<HashSet<String>>>,
     #[cfg(target_os = "windows")]
     com: Arc<RwLock<Option<com_thread::ComThreadHandle>>>,
@@ -133,7 +139,7 @@ impl WinAudioDriver {
     }
 
     /// Wire the driver to the unified feedback channel.
-    pub async fn set_feedback_sender(&self, tx: mpsc::Sender<(String, Vec<u8>)>) {
+    pub async fn set_feedback_sender(&self, tx: mpsc::Sender<FeedbackMsg>) {
         *self.feedback_tx.write().await = Some(tx);
     }
 }

--- a/src/drivers/winaudio/session.rs
+++ b/src/drivers/winaudio/session.rs
@@ -4,8 +4,9 @@
 //! sessions to their owning process via `IAudioSessionControl2::GetProcessId`
 //! plus `QueryFullProcessImageNameW`. Volume changes use `ISimpleAudioVolume`
 //! (which every session control instance can be cast to).
-
-#![cfg(target_os = "windows")]
+//!
+//! Module is `#[cfg(target_os = "windows")]`-gated at its parent declaration
+//! in `mod.rs`.
 
 use std::path::PathBuf;
 

--- a/src/drivers/winaudio/session_events.rs
+++ b/src/drivers/winaudio/session_events.rs
@@ -6,8 +6,9 @@
 //! Both callbacks fire on a WASAPI-internal thread, so the bodies must
 //! be non-blocking. They communicate back to the COM thread by pushing
 //! events / commands through `mpsc` channels (`try_send`, drop on full).
-
-#![cfg(target_os = "windows")]
+//!
+//! Module is `#[cfg(target_os = "windows")]`-gated at its parent declaration
+//! in `mod.rs`.
 
 use tokio::sync::mpsc;
 use tracing::trace;

--- a/src/input/gamepad/analog.rs
+++ b/src/input/gamepad/analog.rs
@@ -48,28 +48,10 @@ pub fn apply_inversion(value: f32, axis_id: &str, config: &AnalogConfig) -> f32 
     }
 }
 
-/// Scale analog value to MIDI CC range (0-127)
-pub fn to_midi_cc(value: f32) -> u8 {
-    // Map -1.0..1.0 → 0..127
-    let scaled = ((value + 1.0) / 2.0 * 127.0).round();
-    scaled.clamp(0.0, 127.0) as u8
-}
-
-/// Scale analog value to MIDI PitchBend range (0-16383)
-pub fn to_midi_pb(value: f32) -> u16 {
-    // Map -1.0..1.0 → 0..16383
-    let scaled = ((value + 1.0) / 2.0 * 16383.0).round();
-    scaled.clamp(0.0, 16383.0) as u16
-}
-
-/// Convert button state to MIDI value
-pub fn button_to_midi(pressed: bool) -> u8 {
-    if pressed {
-        127
-    } else {
-        0
-    }
-}
+// NOTE: `to_midi_cc` / `to_midi_pb` / `button_to_midi` helpers were
+// removed (PR-C2). The canonical 14-bit / 7-bit MIDI scaling lives in
+// `crate::midi` (`to_7bit_from_14bit`, `from_percent_14bit`, etc.) and
+// the gamepad-to-MIDI mapping never wired these analog helpers.
 
 #[cfg(test)]
 mod tests {
@@ -120,25 +102,5 @@ mod tests {
         assert_eq!(apply_inversion(0.5, "lx", &config), 0.5); // Not inverted
         assert_eq!(apply_inversion(0.5, "ly", &config), -0.5); // Inverted
         assert_eq!(apply_inversion(-0.5, "ly", &config), 0.5); // Inverted
-    }
-
-    #[test]
-    fn test_midi_cc_scaling() {
-        assert_eq!(to_midi_cc(-1.0), 0);
-        assert_eq!(to_midi_cc(0.0), 64); // Middle (rounding)
-        assert_eq!(to_midi_cc(1.0), 127);
-    }
-
-    #[test]
-    fn test_midi_pb_scaling() {
-        assert_eq!(to_midi_pb(-1.0), 0);
-        assert_eq!(to_midi_pb(0.0), 8192); // Middle (rounding)
-        assert_eq!(to_midi_pb(1.0), 16383);
-    }
-
-    #[test]
-    fn test_button_to_midi() {
-        assert_eq!(button_to_midi(true), 127);
-        assert_eq!(button_to_midi(false), 0);
     }
 }

--- a/src/input/gamepad/diagnostics.rs
+++ b/src/input/gamepad/diagnostics.rs
@@ -10,6 +10,10 @@ use tracing::info;
 ///
 /// This is useful for troubleshooting gamepad detection issues,
 /// especially for Bluetooth controllers that may have non-obvious names.
+///
+/// Currently uncalled — kept as a CLI/REPL diagnostic tool. Wire to a
+/// `diag` subcommand when needed.
+#[allow(dead_code)]
 pub fn print_gamepad_diagnostics() {
     info!("=== Hybrid Gamepad Diagnostics ===");
     info!("Platform: {}", std::env::consts::OS);

--- a/src/input/gamepad/hybrid_id.rs
+++ b/src/input/gamepad/hybrid_id.rs
@@ -5,6 +5,7 @@
 //! to manage controllers from both sources uniformly.
 
 use gilrs::GamepadId;
+use std::fmt;
 
 /// Unified controller identifier across backends
 ///
@@ -35,16 +36,18 @@ impl HybridControllerId {
     pub fn from_xinput(user_index: usize) -> Self {
         Self::XInput(user_index)
     }
+}
 
-    /// Get a stable string identifier for logging and debugging
-    ///
-    /// # Examples
-    /// - Gilrs: "gilrs:0"
-    /// - XInput: "xinput:0"
-    pub fn to_string(&self) -> String {
+/// Stable string formatting for logging and debugging.
+///
+/// # Examples
+/// - Gilrs: "gilrs:0"
+/// - XInput: "xinput:0"
+impl fmt::Display for HybridControllerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Gilrs(id) => format!("gilrs:{:?}", id),
-            Self::XInput(idx) => format!("xinput:{}", idx),
+            Self::Gilrs(id) => write!(f, "gilrs:{:?}", id),
+            Self::XInput(idx) => write!(f, "xinput:{}", idx),
         }
     }
 }

--- a/src/input/gamepad/hybrid_provider/gilrs_events.rs
+++ b/src/input/gamepad/hybrid_provider/gilrs_events.rs
@@ -10,7 +10,7 @@ use crate::input::gamepad::axis::gilrs_axis_to_control_id;
 use crate::input::gamepad::hybrid_id::HybridControllerId;
 use crate::input::gamepad::hybrid_provider::GamepadEvent;
 use crate::input::gamepad::normalize::normalize_gilrs_stick;
-use crate::input::gamepad::stick_buffer::{StickBuffer, StickId};
+use crate::input::gamepad::stick_buffer::StickId;
 use crate::input::gamepad::GAMEPAD_PREFIX;
 
 impl HybridProviderState {
@@ -102,10 +102,7 @@ impl HybridProviderState {
         use gilrs::Axis;
 
         let buffer_key = (id, stick);
-        let buffer = self
-            .gilrs_stick_buffer
-            .entry(buffer_key)
-            .or_insert_with(StickBuffer::default);
+        let buffer = self.gilrs_stick_buffer.entry(buffer_key).or_default();
 
         match axis {
             Axis::LeftStickX | Axis::RightStickX => buffer.x = value,

--- a/src/input/gamepad/hybrid_provider/mod.rs
+++ b/src/input/gamepad/hybrid_provider/mod.rs
@@ -37,7 +37,12 @@ pub enum GamepadEvent {
         control_id: String, // Full ID: "gamepad1.axis.lx"
         value: f32,
         analog_config: Option<AnalogConfig>, // Per-slot config
-        /// Monotonic sequence number for ordering (prevents race conditions under CPU load)
+        /// Monotonic sequence number for ordering. The current consumer
+        /// (`mapper::spawn_event_processor`) processes events in receive
+        /// order so the field is currently unused; retained on the wire
+        /// so out-of-order consumers (e.g. a future parallel dispatcher)
+        /// can reorder without a breaking change.
+        #[allow(dead_code)]
         sequence: u64,
     },
 }

--- a/src/input/gamepad/normalize.rs
+++ b/src/input/gamepad/normalize.rs
@@ -91,6 +91,12 @@ pub fn normalize_stick_radial(raw_x: i16, raw_y: i16, deadzone: f32) -> (f32, f3
 pub enum GilrsNormMode {
     /// No transformation - pass through raw values, only clamp if magnitude > 1.
     /// Use if raw values already form a circle.
+    //
+    // Allowed dead variant: `GILRS_NORM_MODE` is currently fixed to
+    // `SquareToCircle`. These variants exist so the const can be flipped
+    // for empirical stick-shape testing without re-introducing the
+    // experiment branches.
+    #[allow(dead_code)]
     RadialClamp,
 
     /// Square to circle - shrink diagonals. Use if raw values form a square
@@ -101,6 +107,7 @@ pub enum GilrsNormMode {
     /// Astroid/diamond to circle - expand diagonals. Use if raw values form
     /// a concave diamond (diagonals pulled inward, magnitude < 1).
     /// Scales up diagonal values to reach magnitude 1.0.
+    #[allow(dead_code)]
     AstroidToCircle,
 }
 

--- a/src/input/gamepad/slot.rs
+++ b/src/input/gamepad/slot.rs
@@ -154,6 +154,7 @@ impl SlotManager {
     }
 
     /// Get all slots (immutable)
+    #[allow(dead_code)] // Public introspection API kept for the diagnostic CLI.
     pub fn slots(&self) -> &[GamepadSlot] {
         &self.slots
     }
@@ -259,11 +260,13 @@ impl SlotManager {
     }
 
     /// Get the number of slots
+    #[allow(dead_code)] // Collection-style introspection kept for diagnostic / test code.
     pub fn len(&self) -> usize {
         self.slots.len()
     }
 
     /// Check if there are no slots
+    #[allow(dead_code)] // Collection-style introspection kept for diagnostic / test code.
     pub fn is_empty(&self) -> bool {
         self.slots.is_empty()
     }

--- a/src/input/gamepad/visualizer_state.rs
+++ b/src/input/gamepad/visualizer_state.rs
@@ -72,8 +72,14 @@ impl StickTrail {
 pub enum ControllerBackend {
     /// XInput controller (Xbox, etc.)
     XInput { user_index: u32, packet_number: u32 },
-    /// HID controller via gilrs
-    Gilrs { gamepad_id: GamepadId, name: String },
+    /// HID controller via gilrs. `gamepad_id` is the gilrs handle (carried
+    /// here so the visualizer UI can render it on hover); `name` is the
+    /// friendly product name shown in the controller header.
+    Gilrs {
+        #[allow(dead_code)]
+        gamepad_id: GamepadId,
+        name: String,
+    },
 }
 
 /// State for all controllers being visualized

--- a/src/input/gamepad/xinput_convert.rs
+++ b/src/input/gamepad/xinput_convert.rs
@@ -220,7 +220,7 @@ mod tests {
                 pressed,
             } => {
                 assert_eq!(control_id, "gamepad1.btn.a");
-                assert_eq!(*pressed, true);
+                assert!(*pressed);
             },
             _ => panic!("Expected button event"),
         }

--- a/src/obs_indicators.rs
+++ b/src/obs_indicators.rs
@@ -65,6 +65,12 @@ pub fn build_indicator_callback(
 ///
 /// Evaluates which controls should be lit, sends LED updates, and handles
 /// scene change broadcasts for the Stream Deck API.
+//
+// Args are the full set of dependencies needed to fan out to LED, scene-
+// broadcast and auto-target side-effects from one OBS signal. Bundling
+// them into a context struct would just move the boilerplate to the
+// single call site, so keep the wide signature and silence clippy.
+#[allow(clippy::too_many_arguments)]
 async fn handle_indicator_signal(
     router: &Router,
     control_db: &ControlMappingDB,
@@ -97,14 +103,12 @@ fn send_led_updates(
     led_tx: &mpsc::Sender<Vec<u8>>,
 ) {
     for (control_id, should_be_lit) in lit_controls.iter() {
-        if let Some(midi_spec) = control_db.get_midi_spec(control_id, is_mcu_mode) {
-            if let MidiSpec::Note { note } = midi_spec {
-                let velocity = if *should_be_lit { 127 } else { 0 };
-                let midi_msg = vec![0x90, note, velocity]; // Note On, channel 1
+        if let Some(MidiSpec::Note { note }) = control_db.get_midi_spec(control_id, is_mcu_mode) {
+            let velocity = if *should_be_lit { 127 } else { 0 };
+            let midi_msg = vec![0x90, note, velocity]; // Note On, channel 1
 
-                if let Err(e) = led_tx.try_send(midi_msg) {
-                    warn!("Failed to send LED update to channel: {}", e);
-                }
+            if let Err(e) = led_tx.try_send(midi_msg) {
+                warn!("Failed to send LED update to channel: {}", e);
             }
         }
     }

--- a/src/router/camera_target.rs
+++ b/src/router/camera_target.rs
@@ -115,12 +115,16 @@ impl CameraTargetState {
         targets.get(gamepad_slot).cloned()
     }
 
-    /// Get all current camera targets
+    /// Get all current camera targets. Reserved for the upcoming
+    /// `/api/cameras/targets` HTTP endpoint and the Stream Deck
+    /// "current target per slot" view.
+    #[allow(dead_code)]
     pub fn get_all_targets(&self) -> HashMap<String, String> {
         self.targets.read().clone()
     }
 
     /// Clear the camera target for a gamepad slot
+    #[allow(dead_code)] // Exercised by `tests::test_clear_target`.
     pub fn clear_target(&self, gamepad_slot: &str) -> Result<()> {
         // Remove from in-memory state
         {


### PR DESCRIPTION
## Summary
Completes #24. PR-C1 (#49) cleaned 99 -> 27 warnings; the remaining 27 lived in files owned by parallel open PRs. Now that those PRs (#46, #47, #48, #50) have stabilized, this PR finishes the sweep.

**Stacked on PR #50** (feat/winaudio-quality). Will auto-rebase to main once #50 merges.

## Categories

### winaudio (commit `ccc79c3`)
- Drop 6 redundant `#![cfg(target_os = "windows")]` inner-attributes; the parent `mod.rs` already gates the submodules.
- Type-alias the `Arc<RwLock<Option<mpsc::Sender<(String, Vec<u8>)>>>>` field as `FeedbackSender` / `FeedbackMsg` (`clippy::type_complexity`).
- `#[cfg(test)]`-gate `mapping::SlotBinding` + `mapping::compute_slots` (only consumed by tests; production code resolves per-fader on demand). Fix the `needless_range_loop` while at it.

### gamepad (commit `010dff7`)
- Delete unused `analog::{to_midi_cc, to_midi_pb, button_to_midi}` and their tests — canonical MIDI scaling lives in `crate::midi`.
- `#[allow(dead_code)]` (with rationale) on: `diagnostics::print_gamepad_diagnostics`, `GamepadEvent::Axis::sequence`, `GilrsNormMode::{RadialClamp, AstroidToCircle}`, `SlotManager::{slots, len, is_empty}`, `ControllerBackend::Gilrs::gamepad_id`.
- Replace inherent `HybridControllerId::to_string` with `impl Display` (silences both `inherent_to_string` and `wrong_self_convention`; existing `.to_string()` callers keep working via the blanket impl).
- `or_insert_with(StickBuffer::default)` -> `or_default()` (drops the import too).
- `assert_eq!(*pressed, true)` -> `assert!(*pressed)`.

### obs / router / config (commit `826f01e`)
- `obs_indicators`: collapse nested `if let Some(...)` + `if let MidiSpec::Note { note }`; `#[allow(clippy::too_many_arguments)]` on `handle_indicator_signal` (single fan-out call site, same rationale as PR-C1's `run_app`).
- `router::camera_target`: `#[allow(dead_code)]` on `get_all_targets` (reserved for the upcoming HTTP endpoint) and `clear_target` (exercised by the test suite).
- `config::AppConfig::save`: `#[allow(dead_code)]` with rationale (canonical YAML serializer kept for the future editor write path). Does **not** touch the `validate()` block added by PR-W2.

### `gamepad_mapper` regression
PR-C1 flagged a `gamepad_mapper assigned but never read` warning to investigate. **It did not reproduce on this branch** — likely resolved by PR #46's gamepad work that has since landed in main. `cargo clippy --all-targets -- -D warnings` is clean across the workspace.

## Stats
- Warnings before: **27**
- Warnings after: **0**
- Tests: 239 pass (3 fewer than before because the 3 deleted `analog.rs` MIDI helpers had trivial round-trip tests; no production logic lost)

## Test plan
- [x] `cargo test` clean (239 passing across lib + integration suites)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo build` clean (release build fails pre-existing on `editor`/`build`, ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)