### PR TITLE
v1.9.0 follow-ups: MIDI liveness/leak fixes + feedback toggles

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -304,9 +304,29 @@ pages_global:
       app: "qlc"
       midi: { type: "cc", channel: 1, cc: 12 }
 
+    # Exemple multi-action : un contrôle peut déclencher des effets supplémentaires
+    # `record` illustre les trois mécanismes d'un contrôle :
+    #  1. effet primaire (app/action/params/midi inline) — ici passthrough Voicemeeter
+    #  2. `also` : effets supplémentaires À L'APPUI (midi = deux fronts, action = appui seul)
+    #  3. `toggle` : actions pilotées par le STATUT RÉEL renvoyé par un app (son feedback),
+    #     pas par l'appui. Front OFF→ON déclenche `on`, front ON→OFF déclenche `off`
+    #     (détection de front : un état répété ne re-déclenche pas). `source` = app dont on
+    #     lit le feedback (défaut : `app`). `watch` (optionnel) fixe l'adresse MIDI surveillée ;
+    #     par défaut = adresse hardware du contrôle. Les étapes `midi:` n'y sont pas supportées.
     record:
       app: "voicemeeter"
-      midi: {type: "passthrough"}
+      midi: {type: "passthrough"}      # primaire : passthrough Voicemeeter
+      also:
+        - app: "qlc"                   # CC custom (127 à l'appui / 0 au relâché)
+          midi: { type: "cc", channel: 1, cc: 20 }
+      toggle:
+        source: "voicemeeter"
+        # watch: { type: note, channel: 1, note: 95 }   # optionnel (défaut : adresse hw du contrôle)
+        on:                            # Voicemeeter passe ON  → caméra Main en programme
+          - { app: "obs", action: "selectCamera", params: ["Main", "program"] }
+        off:                           # Voicemeeter passe OFF → scène d'outro en PROGRAMME
+          # changeScene : 2e param "program"/"preview" force la cible ; sinon suit le studio mode.
+          - { app: "obs", action: "changeScene", params: ["End", "program"] }
 
 # Apps audio Windows pinnées sur des faders fixes. Les autres faders se
 # remplissent en FIFO depuis les sessions audio actives au démarrage.

--- a/src/app.rs
+++ b/src/app.rs
@@ -96,8 +96,10 @@ pub async fn run_app(
     // `tokio::spawn`), so the lack of `Sync` is benign. We keep `Arc` (over
     // `Rc`) so the same value can later be wired into multi-threaded paths
     // without re-typing the entire surface.
+    // `mut` so the X-Touch link health monitor (below) can rebuild the driver
+    // in place after a USB hiccup / replug without restarting the app.
     #[allow(clippy::arc_with_non_send_sync)]
-    let xtouch = Arc::new(xtouch);
+    let mut xtouch = Arc::new(xtouch);
     display::update_xtouch_display(&router, &xtouch).await;
     info!("X-Touch display initialized");
 
@@ -310,6 +312,19 @@ pub async fn run_app(
     // Consume the immediate first tick so we don't snapshot at t=0.
     snapshot_tick.tick().await;
 
+    // X-Touch link health monitor. The X-Touch has no runtime reconnect: a USB
+    // hiccup, replug, or Windows power-save silently kills input (the MIDI
+    // callback stops) and output (sends start erroring), and recovery
+    // otherwise needs an app restart. We poll port presence plus an
+    // output-failure flag and rebuild the driver in place when the link is
+    // down. Runs faster than the snapshot cadence so a dropped link recovers
+    // within a few seconds of the hardware coming back.
+    let mut xtouch_health_tick = tokio::time::interval(std::time::Duration::from_secs(3));
+    xtouch_health_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    xtouch_health_tick.tick().await; // consume immediate tick
+    let xtouch_out_failed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let mut xtouch_link_down = false;
+
     loop {
         tokio::select! {
             // Apply fader setpoints (from FaderSetpoint async tasks)
@@ -320,6 +335,7 @@ pub async fn run_app(
                     let fader_num = cmd.channel - 1;
                     if let Err(_e) = xtouch.set_fader(fader_num, cmd.value14).await {
                         trace!("Setpoint apply failed, requeueing: ch={} value={}", cmd.channel, cmd.value14);
+                        xtouch_out_failed.store(true, std::sync::atomic::Ordering::Relaxed);
                         setpoint.schedule(cmd.channel, cmd.value14, Some(120));
                     }
                 } else {
@@ -331,6 +347,7 @@ pub async fn run_app(
             Some(midi_msg) = led_rx.recv() => {
                 if let Err(e) = xtouch.send_raw(&midi_msg).await {
                     warn!("Failed to send LED update: {}", e);
+                    xtouch_out_failed.store(true, std::sync::atomic::Ordering::Relaxed);
                 }
             }
 
@@ -409,6 +426,61 @@ pub async fn run_app(
                 if crate::cli::process_command(&line, router.get_state_actor()).await {
                     info!("Exit requested from REPL");
                     break;
+                }
+            }
+
+            // X-Touch link health check + in-place reconnect
+            _ = xtouch_health_tick.tick() => {
+                let (in_pat, out_pat) = {
+                    let cfg = router.config.read().await;
+                    (cfg.midi.input_port.clone(), cfg.midi.output_port.clone())
+                };
+                let present = xtouch_ports_present(&in_pat, &out_pat);
+                let had_out_failure =
+                    xtouch_out_failed.swap(false, std::sync::atomic::Ordering::Relaxed);
+
+                // Mark the link down on first detection (ports vanished, or a
+                // send failed while the port is still enumerable — a wedged
+                // device). Logged once per down episode, not per tick.
+                if !xtouch_link_down && (!present || had_out_failure) {
+                    xtouch_link_down = true;
+                    warn!(
+                        "X-Touch link down (ports_present={}, send_failed={}); will reconnect when the port is available",
+                        present, had_out_failure
+                    );
+                    let _ = live_tx.send(crate::event_bus::LiveEvent::Connection {
+                        target: "xtouch".into(),
+                        status: crate::event_bus::ConnectionStatus::Down,
+                        detail: Some("link lost".into()),
+                        ts: crate::event_bus::now_ms(),
+                    });
+                }
+
+                // Once the port is back (and we believe we're down), rebuild
+                // the driver in place: a fresh connection reuses the same event
+                // channel, so the receiver swap below keeps the loop wired.
+                if xtouch_link_down && present {
+                    match reconnect_xtouch(&router).await {
+                        Some((new_driver, new_rx)) => {
+                            xtouch = new_driver;
+                            xtouch_rx = new_rx;
+                            xtouch_link_down = false;
+                            xtouch_out_failed.store(false, std::sync::atomic::Ordering::Relaxed);
+                            info!("X-Touch reconnected");
+                            // Repaint the surface and replay current page state
+                            // (faders/LEDs/LCD) onto the freshly opened device.
+                            display::update_xtouch_display(&router, &xtouch).await;
+                            router.refresh_page().await;
+                            display::flush_pending_midi(&router, &xtouch, "xtouch reconnect").await;
+                            let _ = live_tx.send(crate::event_bus::LiveEvent::Connection {
+                                target: "xtouch".into(),
+                                status: crate::event_bus::ConnectionStatus::Up,
+                                detail: Some("reconnect".into()),
+                                ts: crate::event_bus::now_ms(),
+                            });
+                        },
+                        None => warn!("X-Touch reconnect attempt failed; will retry"),
+                    }
                 }
             }
 
@@ -522,6 +594,52 @@ fn publish_profiles_list(
     };
     let active = profile_store.active().ok();
     let _ = tray_update_tx.try_send(crate::tray::TrayUpdate::ProfilesList { profiles, active });
+}
+
+/// Probe whether both configured X-Touch ports are currently enumerable.
+/// Used by the link health monitor to detect an unplugged / suspended device
+/// before attempting an in-place reconnect.
+fn xtouch_ports_present(input_pattern: &str, output_pattern: &str) -> bool {
+    let contains = |names: &[String], pat: &str| {
+        let pat = pat.to_lowercase();
+        names.iter().any(|n| n.to_lowercase().contains(&pat))
+    };
+    let inputs = XTouchDriver::list_input_ports().unwrap_or_default();
+    let outputs = XTouchDriver::list_output_ports().unwrap_or_default();
+    contains(&inputs, input_pattern) && contains(&outputs, output_pattern)
+}
+
+/// Rebuild and reconnect the X-Touch driver from the router's *current* config
+/// (so port-name changes from a profile reload are honoured). Returns the new
+/// driver handle and its event receiver, or `None` if the rebuild/connect
+/// failed (e.g. the port isn't actually openable yet) so the caller retries.
+///
+/// The fresh input callback reuses a brand-new event channel; the caller swaps
+/// in the returned receiver so the main loop keeps receiving X-Touch input.
+async fn reconnect_xtouch(
+    router: &Arc<Router>,
+) -> Option<(
+    Arc<XTouchDriver>,
+    mpsc::Receiver<crate::xtouch::XTouchEvent>,
+)> {
+    let mut driver = {
+        let cfg = router.config.read().await;
+        match XTouchDriver::new(&cfg) {
+            Ok(d) => d,
+            Err(e) => {
+                warn!("X-Touch rebuild failed: {}", e);
+                return None;
+            },
+        }
+    };
+    if let Err(e) = driver.connect().await {
+        warn!("X-Touch reconnect: connect failed: {}", e);
+        return None;
+    }
+    let rx = driver.take_event_receiver()?;
+    #[allow(clippy::arc_with_non_send_sync)]
+    let driver = Arc::new(driver);
+    Some((driver, rx))
 }
 
 /// Perform shutdown cleanup: stop drivers, save state, reset hardware.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -317,6 +317,72 @@ pub struct ControlMapping {
     pub overlay: Option<OverlayConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indicator: Option<IndicatorConfig>,
+    /// Effets supplémentaires déclenchés en plus de l'effet primaire (boutons multi-action).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub also: Option<Vec<ActionStep>>,
+    /// Actions déclenchées par le *feedback* d'un app (transition on/off de son
+    /// état réel), et non par l'appui bouton. Voir [`ToggleConfig`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub toggle: Option<ToggleConfig>,
+}
+
+impl ControlMapping {
+    /// L'effet primaire du contrôle, sous forme d'étape de dispatch.
+    ///
+    /// Permet au routeur de traiter l'effet inline historique
+    /// (`app`/`action`/`params`/`midi`) et chaque entrée de `also` via le même
+    /// chemin de code.
+    pub fn primary_step(&self) -> ActionStep {
+        ActionStep {
+            app: self.app.clone(),
+            action: self.action.clone(),
+            params: self.params.clone(),
+            midi: self.midi.clone(),
+        }
+    }
+}
+
+/// Une étape de dispatch : un effet unique (action driver OU envoi MIDI direct).
+///
+/// Sert à la fois pour l'effet primaire d'un contrôle et pour chaque entrée de
+/// `ControlMapping::also`. Si `midi` est présent, l'étape part en MIDI direct
+/// (passthrough/transform) ; sinon elle exécute `action` sur le driver `app`.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ActionStep {
+    pub app: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<Vec<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi: Option<MidiSpec>,
+}
+
+/// Toggle piloté par le feedback d'un app.
+///
+/// Au lieu de se déclencher sur l'appui du bouton (comportement de `action`/`also`,
+/// front montant uniquement), un toggle réagit au **statut réel** renvoyé par un app
+/// sur son port de feedback : front OFF→ON (valeur > 0) déclenche `on`, front ON→OFF
+/// (valeur == 0) déclenche `off`. La détection de front rend le déclenchement
+/// idempotent (un état répété ne re-déclenche pas).
+///
+/// Les étapes `on`/`off` sont des actions driver (ex. `selectCamera`, `changeScene`) ;
+/// les étapes `midi` n'y sont pas supportées (le message déclencheur est synthétique).
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ToggleConfig {
+    /// App dont le feedback pilote le toggle. Défaut : le champ `app` du contrôle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Adresse MIDI surveillée dans le feedback. Optionnel : par défaut, l'adresse
+    /// hardware du contrôle (résolue via `control_mapping`, selon le mode mcu/ctrl).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watch: Option<MidiSpec>,
+    /// Étapes déclenchées au front OFF→ON (valeur > 0).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub on: Vec<ActionStep>,
+    /// Étapes déclenchées au front ON→OFF (valeur == 0).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub off: Vec<ActionStep>,
 }
 
 /// MIDI control specification
@@ -474,6 +540,22 @@ impl AppConfig {
         ) {
             for mapping in controls.values() {
                 apps.insert(mapping.app.clone());
+                // Secondary effects (`also`) and feedback toggles can reference
+                // apps the primary `app` doesn't, so a driver used solely there
+                // is not pruned on reload.
+                if let Some(steps) = &mapping.also {
+                    for step in steps {
+                        apps.insert(step.app.clone());
+                    }
+                }
+                if let Some(toggle) = &mapping.toggle {
+                    if let Some(source) = &toggle.source {
+                        apps.insert(source.clone());
+                    }
+                    for step in toggle.on.iter().chain(toggle.off.iter()) {
+                        apps.insert(step.app.clone());
+                    }
+                }
             }
         }
 
@@ -697,32 +779,56 @@ impl AppConfig {
         Ok(())
     }
 
-    /// Validate a single control mapping
+    /// Validate a single control mapping: its inline primary effect plus any
+    /// `also` fan-out steps. Each step is checked independently.
     fn validate_control_mapping(
         &self,
         control_id: &str,
         mapping: &ControlMapping,
         midi_app_names: &std::collections::HashSet<&String>,
     ) -> Result<()> {
-        if mapping.app.is_empty() {
+        // Primary (inline) effect.
+        self.validate_action_step(control_id, &mapping.primary_step(), midi_app_names)?;
+
+        // Additional fan-out steps (multi-action buttons).
+        if let Some(steps) = &mapping.also {
+            for (idx, step) in steps.iter().enumerate() {
+                self.validate_action_step(control_id, step, midi_app_names)
+                    .with_context(|| {
+                        format!("in `also` step {} of control '{}'", idx, control_id)
+                    })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate one dispatch step (the inline primary effect or one `also`
+    /// entry): app reference, MIDI spec validity, and action-or-midi presence.
+    fn validate_action_step(
+        &self,
+        control_id: &str,
+        step: &ActionStep,
+        midi_app_names: &std::collections::HashSet<&String>,
+    ) -> Result<()> {
+        if step.app.is_empty() {
             anyhow::bail!("Control '{}' app name cannot be empty", control_id);
         }
 
         // Validate app name references a configured app
         // (obs, winaudio, winmedia are non-MIDI apps that don't need a port entry).
         const NON_MIDI_APPS: &[&str] = &["obs", "winaudio", "winmedia"];
-        if !NON_MIDI_APPS.contains(&mapping.app.as_str()) && !midi_app_names.contains(&mapping.app)
-        {
+        if !NON_MIDI_APPS.contains(&step.app.as_str()) && !midi_app_names.contains(&step.app) {
             anyhow::bail!(
                 "Control '{}' references unknown app '{}'. Available apps: {:?}",
                 control_id,
-                mapping.app,
+                step.app,
                 midi_app_names
             );
         }
 
         // Validate MIDI specification if present
-        if let Some(midi_spec) = &mapping.midi {
+        if let Some(midi_spec) = &step.midi {
             match midi_spec.midi_type {
                 MidiType::Cc => {
                     if midi_spec.cc.is_none() {
@@ -795,7 +901,7 @@ impl AppConfig {
         }
 
         // Validate that action OR midi is specified (not both empty, unless passthrough)
-        if mapping.action.is_none() && mapping.midi.is_none() {
+        if step.action.is_none() && step.midi.is_none() {
             anyhow::bail!(
                 "Control '{}' must specify either 'action' or 'midi'",
                 control_id
@@ -975,6 +1081,96 @@ mod tests {
         assert_eq!(win.pinned_apps.len(), 3);
     }
 
+    /// The shipped Twitch profile must parse + validate. Its Record button keeps
+    /// the Voicemeeter passthrough primary + a QLC CC via `also` (on press), and
+    /// drives the OBS camera from the Voicemeeter feedback *status* via `toggle`:
+    /// `selectCamera` on the ON edge, `changeScene` on the OFF edge.
+    #[test]
+    fn twitch_profile_record_drives_obs_from_toggle() {
+        let yaml = std::fs::read_to_string("profiles/twitch.yaml")
+            .expect("profiles/twitch.yaml must exist");
+        let parsed: AppConfig = serde_yaml::from_str(&yaml).expect("YAML parse failed");
+        parsed.validate().expect("config validation failed");
+
+        let global = parsed.pages_global.as_ref().expect("pages_global expected");
+        let controls = global.controls.as_ref().expect("global controls expected");
+        let record = controls.get("record").expect("record control expected");
+        assert_eq!(record.app, "voicemeeter");
+        assert!(
+            record.midi.is_some(),
+            "primary stays Voicemeeter passthrough"
+        );
+
+        // `also`: QLC CC fires on press (the OBS camera moved to `toggle`).
+        let also = record.also.as_ref().expect("record must have `also` steps");
+        assert!(
+            also.iter().any(|s| s.app == "qlc" && s.midi.is_some()),
+            "an `also` step must send a MIDI message to QLC"
+        );
+
+        // `toggle`: driven by the Voicemeeter feedback status.
+        let toggle = record
+            .toggle
+            .as_ref()
+            .expect("record must carry a `toggle`");
+        assert_eq!(toggle.source.as_deref(), Some("voicemeeter"));
+        assert!(
+            toggle
+                .on
+                .iter()
+                .any(|s| s.app == "obs" && s.action.as_deref() == Some("selectCamera")),
+            "ON edge must select the OBS camera"
+        );
+        assert!(
+            toggle
+                .off
+                .iter()
+                .any(|s| s.app == "obs" && s.action.as_deref() == Some("changeScene")),
+            "OFF edge must change to the OBS outro scene"
+        );
+    }
+
+    /// Multi-action: an `also` step referencing an app that is neither a
+    /// non-MIDI app nor a configured MIDI app must be rejected at load, with
+    /// the same safety net as the inline primary effect.
+    #[test]
+    fn validate_rejects_unknown_app_in_also_step() {
+        let mut cfg = empty_config();
+        let mut controls = HashMap::new();
+        controls.insert(
+            "record".into(),
+            ControlMapping {
+                app: "obs".into(),
+                action: Some("toggleStudioMode".into()),
+                params: None,
+                midi: None,
+                indicator: None,
+                overlay: None,
+                also: Some(vec![ActionStep {
+                    app: "nope_typo".into(),
+                    action: Some("x".into()),
+                    params: None,
+                    midi: None,
+                }]),
+                toggle: None,
+            },
+        );
+        cfg.pages.push(PageConfig {
+            name: "P".into(),
+            controls: Some(controls),
+            ..PageConfig::default()
+        });
+
+        let err = cfg
+            .validate()
+            .expect_err("unknown app in `also` step must fail validation");
+        let chain = format!("{:#}", err);
+        assert!(
+            chain.contains("nope_typo"),
+            "error chain should name the offending app: {chain}"
+        );
+    }
+
     fn empty_config() -> AppConfig {
         AppConfig {
             midi: MidiConfig {
@@ -1001,6 +1197,8 @@ mod tests {
             midi: None,
             indicator: None,
             overlay: None,
+            also: None,
+            toggle: None,
         }
     }
 
@@ -1101,6 +1299,8 @@ mod tests {
             midi: None,
             indicator: None,
             overlay: None,
+            also: None,
+            toggle: None,
         }
     }
 
@@ -1181,6 +1381,8 @@ mod tests {
                 midi: None,
                 indicator: None,
                 overlay: None,
+                also: None,
+                toggle: None,
             },
         );
         cfg.midi.apps = Some(vec![MidiAppConfig {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -800,6 +800,11 @@ impl AppConfig {
             }
         }
 
+        // Feedback-driven toggle (source app, watched address, on/off steps).
+        if let Some(toggle) = &mapping.toggle {
+            self.validate_toggle(control_id, toggle, midi_app_names)?;
+        }
+
         Ok(())
     }
 
@@ -817,7 +822,6 @@ impl AppConfig {
 
         // Validate app name references a configured app
         // (obs, winaudio, winmedia are non-MIDI apps that don't need a port entry).
-        const NON_MIDI_APPS: &[&str] = &["obs", "winaudio", "winmedia"];
         if !NON_MIDI_APPS.contains(&step.app.as_str()) && !midi_app_names.contains(&step.app) {
             anyhow::bail!(
                 "Control '{}' references unknown app '{}'. Available apps: {:?}",
@@ -910,7 +914,124 @@ impl AppConfig {
 
         Ok(())
     }
+
+    /// Validate a feedback-driven toggle: its `source` app (when set), the
+    /// watched MIDI address (when set), and every `on`/`off` step. Toggle steps
+    /// run via a synthetic trigger, so a `midi` step is a hard error here (the
+    /// runtime would only warn + skip it, which is easy to miss).
+    fn validate_toggle(
+        &self,
+        control_id: &str,
+        toggle: &ToggleConfig,
+        midi_app_names: &std::collections::HashSet<&String>,
+    ) -> Result<()> {
+        if let Some(source) = &toggle.source {
+            if source.is_empty() {
+                anyhow::bail!("Control '{}' toggle.source cannot be empty", control_id);
+            }
+            if !NON_MIDI_APPS.contains(&source.as_str()) && !midi_app_names.contains(source) {
+                anyhow::bail!(
+                    "Control '{}' toggle.source references unknown app '{}'. Available apps: {:?}",
+                    control_id,
+                    source,
+                    midi_app_names
+                );
+            }
+        }
+
+        if let Some(watch) = &toggle.watch {
+            Self::validate_watch_spec(control_id, watch)?;
+        }
+
+        for (label, steps) in [("on", &toggle.on), ("off", &toggle.off)] {
+            for (idx, step) in steps.iter().enumerate() {
+                if step.midi.is_some() {
+                    anyhow::bail!(
+                        "Control '{}' toggle.{} step {} uses `midi`, which toggles cannot \
+                         dispatch (the trigger message is synthetic)",
+                        control_id,
+                        label,
+                        idx
+                    );
+                }
+                self.validate_action_step(control_id, step, midi_app_names)
+                    .with_context(|| {
+                        format!(
+                            "in `toggle.{}` step {} of control '{}'",
+                            label, idx, control_id
+                        )
+                    })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate a `toggle.watch` MIDI address: the field actually required to
+    /// match feedback (`note` for note, `cc` for cc), value ranges, and that the
+    /// type is a watchable address (`passthrough` never matches).
+    fn validate_watch_spec(control_id: &str, watch: &MidiSpec) -> Result<()> {
+        match watch.midi_type {
+            MidiType::Note => {
+                if watch.note.is_none() {
+                    anyhow::bail!(
+                        "Control '{}' toggle.watch type 'note' requires a 'note' field",
+                        control_id
+                    );
+                }
+            },
+            MidiType::Cc => {
+                if watch.cc.is_none() {
+                    anyhow::bail!(
+                        "Control '{}' toggle.watch type 'cc' requires a 'cc' field",
+                        control_id
+                    );
+                }
+            },
+            MidiType::Pb => {},
+            MidiType::Passthrough => {
+                anyhow::bail!(
+                    "Control '{}' toggle.watch type 'passthrough' is not a watchable address",
+                    control_id
+                );
+            },
+        }
+
+        if let Some(channel) = watch.channel {
+            if channel == 0 || channel > 16 {
+                anyhow::bail!(
+                    "Control '{}' toggle.watch has invalid channel {} (must be 1-16)",
+                    control_id,
+                    channel
+                );
+            }
+        }
+        if let Some(cc) = watch.cc {
+            if cc > 127 {
+                anyhow::bail!(
+                    "Control '{}' toggle.watch has invalid CC {} (must be 0-127)",
+                    control_id,
+                    cc
+                );
+            }
+        }
+        if let Some(note) = watch.note {
+            if note > 127 {
+                anyhow::bail!(
+                    "Control '{}' toggle.watch has invalid note {} (must be 0-127)",
+                    control_id,
+                    note
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
+
+/// Apps that don't need a MIDI `midi.apps` port entry — they're validated by
+/// name only. Shared by `validate_action_step` and `validate_toggle`.
+const NON_MIDI_APPS: &[&str] = &["obs", "winaudio", "winmedia"];
 
 /// Driver name that owns Windows audio session control. Duplicated here
 /// (and kept in sync with `drivers::winaudio::DRIVER_NAME`) so the lib
@@ -1168,6 +1289,57 @@ mod tests {
         assert!(
             chain.contains("nope_typo"),
             "error chain should name the offending app: {chain}"
+        );
+    }
+
+    /// A `toggle.on`/`off` step cannot carry `midi`: toggles dispatch a
+    /// synthetic trigger, so a MIDI step would only be warn+skipped at runtime.
+    /// Config load must reject it up front instead.
+    #[test]
+    fn validate_rejects_midi_in_toggle_step() {
+        let mut cfg = empty_config();
+        let mut controls = HashMap::new();
+        controls.insert(
+            "record".into(),
+            ControlMapping {
+                app: "obs".into(),
+                action: Some("toggleStudioMode".into()),
+                params: None,
+                midi: None,
+                indicator: None,
+                overlay: None,
+                also: None,
+                toggle: Some(ToggleConfig {
+                    source: None,
+                    watch: None,
+                    on: vec![ActionStep {
+                        app: "obs".into(),
+                        action: None,
+                        params: None,
+                        midi: Some(MidiSpec {
+                            midi_type: MidiType::Note,
+                            channel: Some(1),
+                            cc: None,
+                            note: Some(60),
+                        }),
+                    }],
+                    off: vec![],
+                }),
+            },
+        );
+        cfg.pages.push(PageConfig {
+            name: "P".into(),
+            controls: Some(controls),
+            ..PageConfig::default()
+        });
+
+        let err = cfg
+            .validate()
+            .expect_err("`midi` in a toggle step must fail validation");
+        let chain = format!("{:#}", err);
+        assert!(
+            chain.contains("toggle.on") && chain.contains("midi"),
+            "error should point at the offending toggle step: {chain}"
         );
     }
 

--- a/src/drivers/midibridge.rs
+++ b/src/drivers/midibridge.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use serde_json::Value;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -67,6 +68,13 @@ pub struct MidiBridgeDriver {
     reconnect_count_out: Arc<Mutex<usize>>,
     reconnect_count_in: Arc<Mutex<usize>>,
     shutdown_flag: Arc<Mutex<bool>>,
+    /// Single-flight guards: `true` while a reconnect loop for that direction
+    /// is running, so a send failure or health probe can't spawn a second
+    /// loop racing the first on the exclusive Windows port.
+    reconnecting_out: Arc<AtomicBool>,
+    reconnecting_in: Arc<AtomicBool>,
+    /// Ensures the port-health monitor task is spawned at most once.
+    health_monitor_started: Arc<AtomicBool>,
 }
 
 // Explicitly implement Send and Sync
@@ -108,7 +116,121 @@ impl MidiBridgeDriver {
             reconnect_count_out: Arc::new(Mutex::new(0)),
             reconnect_count_in: Arc::new(Mutex::new(0)),
             shutdown_flag: Arc::new(Mutex::new(false)),
+            reconnecting_out: Arc::new(AtomicBool::new(false)),
+            reconnecting_in: Arc::new(AtomicBool::new(false)),
+            health_monitor_started: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Clone every shared `Arc` handle for use in a spawned background task.
+    /// Centralises the field-by-field clone so adding a shared field only
+    /// needs updating one place (this was previously duplicated inline twice
+    /// in `init`).
+    fn clone_handle(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            to_port: self.to_port.clone(),
+            from_port: self.from_port.clone(),
+            filter: self.filter.clone(),
+            transform: self.transform.clone(),
+            optional: self.optional,
+            midi_out: self.midi_out.clone(),
+            midi_in: self.midi_in.clone(),
+            feedback_callback: self.feedback_callback.clone(),
+            status_callbacks: self.status_callbacks.clone(),
+            current_status: self.current_status.clone(),
+            activity_tracker: self.activity_tracker.clone(),
+            reconnect_count_out: self.reconnect_count_out.clone(),
+            reconnect_count_in: self.reconnect_count_in.clone(),
+            shutdown_flag: self.shutdown_flag.clone(),
+            reconnecting_out: self.reconnecting_out.clone(),
+            reconnecting_in: self.reconnecting_in.clone(),
+            health_monitor_started: self.health_monitor_started.clone(),
+        }
+    }
+
+    /// Spawn the OUT reconnect loop unless one is already running.
+    fn spawn_out_reconnect(&self) {
+        if self.reconnecting_out.swap(true, Ordering::AcqRel) {
+            return; // a loop is already running
+        }
+        let me = self.clone_handle();
+        tokio::spawn(async move {
+            me.schedule_out_reconnect().await;
+            me.reconnecting_out.store(false, Ordering::Release);
+        });
+    }
+
+    /// Spawn the IN reconnect loop unless one is already running.
+    fn spawn_in_reconnect(&self) {
+        if self.reconnecting_in.swap(true, Ordering::AcqRel) {
+            return; // a loop is already running
+        }
+        let me = self.clone_handle();
+        tokio::spawn(async move {
+            me.schedule_in_reconnect().await;
+            me.reconnecting_in.store(false, Ordering::Release);
+        });
+    }
+
+    /// True if the configured OUT port is currently enumerable. On a probe
+    /// failure returns `true` (assume present) so a transient enumeration
+    /// error never tears down a working connection.
+    fn out_port_present(&self) -> bool {
+        midir::MidiOutput::new("XTouch-GW-Bridge-Probe")
+            .ok()
+            .map(|m| find_port_by_substring(&m, &self.to_port).is_some())
+            .unwrap_or(true)
+    }
+
+    /// True if the configured IN port is currently enumerable. See
+    /// `out_port_present` for the probe-failure policy.
+    fn in_port_present(&self) -> bool {
+        midir::MidiInput::new("XTouch-GW-Bridge-Probe")
+            .ok()
+            .map(|m| find_port_by_substring(&m, &self.from_port).is_some())
+            .unwrap_or(true)
+    }
+
+    /// Spawn the periodic port-health monitor (at most once).
+    ///
+    /// A midir *input* connection goes silent without surfacing any error when
+    /// the peer's output port disappears (app restart, USB replug) — the
+    /// callback simply stops firing, so feedback to the X-Touch dies with no
+    /// log. Polling port presence lets us detect that and reconnect. The same
+    /// poll also catches an OUT port that vanished with no send in flight to
+    /// notice it.
+    fn spawn_health_monitor(&self) {
+        if self.health_monitor_started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let me = self.clone_handle();
+        tokio::spawn(async move {
+            loop {
+                sleep(Duration::from_millis(3000)).await;
+                if *me.shutdown_flag.lock() {
+                    return;
+                }
+                if me.midi_out.lock().is_some() && !me.out_port_present() {
+                    warn!(
+                        "MIDI Bridge OUT port '{}' disappeared; reconnecting",
+                        me.to_port
+                    );
+                    *me.midi_out.lock() = None;
+                    me.update_status();
+                    me.spawn_out_reconnect();
+                }
+                if me.midi_in.lock().is_some() && !me.in_port_present() {
+                    warn!(
+                        "MIDI Bridge IN port '{}' disappeared; reconnecting",
+                        me.from_port
+                    );
+                    *me.midi_in.lock() = None;
+                    me.update_status();
+                    me.spawn_in_reconnect();
+                }
+            }
+        });
     }
 
     /// Set the feedback callback for routing MIDI from app to X-Touch
@@ -434,24 +556,44 @@ impl MidiBridgeDriver {
                 },
             };
 
-            // Send message
-            let mut midi_out = self.midi_out.lock();
-            match &mut *midi_out {
-                Some(conn) => {
-                    debug!("Bridge TX -> {}: {:02X?}", self.to_port, transformed);
-                    match conn.send(&transformed) {
-                        Ok(_) => Ok(()),
-                        Err(e) => {
-                            warn!("MIDI Bridge send failed: {}", e);
-                            *midi_out = None; // Close broken connection
-                                              // TODO: Implement reconnection
-                            Err(anyhow!("MIDI send failed: {}", e))
-                        },
+            // Send the message, capturing the outcome and releasing the port
+            // lock before any reconnect bookkeeping (never hold the lock
+            // across a spawn). `bool` flags whether we were connected, so the
+            // not-connected case stays quiet (trace) while a genuine send
+            // failure warns and triggers recovery.
+            let send_outcome: Result<(), (String, bool)> = {
+                let mut midi_out = self.midi_out.lock();
+                match &mut *midi_out {
+                    Some(conn) => {
+                        debug!("Bridge TX -> {}: {:02X?}", self.to_port, transformed);
+                        match conn.send(&transformed) {
+                            Ok(_) => Ok(()),
+                            Err(e) => {
+                                *midi_out = None; // Close broken connection
+                                Err((format!("MIDI send failed: {}", e), true))
+                            },
+                        }
+                    },
+                    None => Err((
+                        format!("MIDI Bridge '{}' not connected", self.to_port),
+                        false,
+                    )),
+                }
+            };
+
+            match send_outcome {
+                Ok(()) => Ok(()),
+                Err((msg, was_connected)) => {
+                    if was_connected {
+                        warn!("MIDI Bridge OUT '{}': {} — reconnecting", self.to_port, msg);
+                        self.update_status();
+                    } else {
+                        trace!("Bridge TX skipped (not connected): {}", self.to_port);
                     }
-                },
-                None => {
-                    trace!("Bridge TX skipped (not connected): {}", self.to_port);
-                    Err(anyhow!("MIDI Bridge '{}' not connected", self.to_port))
+                    // Ensure a reconnect loop is running (single-flight guarded,
+                    // so repeated failures don't pile up tasks).
+                    self.spawn_out_reconnect();
+                    Err(anyhow!(msg))
                 },
             }
         } else {
@@ -483,27 +625,7 @@ impl Driver for MidiBridgeDriver {
             Ok(_) => {},
             Err(e) if self.optional => {
                 warn!("MIDI Bridge OUT open failed (optional): {}", e);
-                // Spawn background reconnection task
-                let self_clone = Self {
-                    name: self.name.clone(),
-                    to_port: self.to_port.clone(),
-                    from_port: self.from_port.clone(),
-                    filter: self.filter.clone(),
-                    transform: self.transform.clone(),
-                    optional: self.optional,
-                    midi_out: self.midi_out.clone(),
-                    midi_in: self.midi_in.clone(),
-                    feedback_callback: self.feedback_callback.clone(),
-                    status_callbacks: self.status_callbacks.clone(),
-                    current_status: self.current_status.clone(),
-                    activity_tracker: self.activity_tracker.clone(),
-                    reconnect_count_out: self.reconnect_count_out.clone(),
-                    reconnect_count_in: self.reconnect_count_in.clone(),
-                    shutdown_flag: self.shutdown_flag.clone(),
-                };
-                tokio::spawn(async move {
-                    self_clone.schedule_out_reconnect().await;
-                });
+                self.spawn_out_reconnect();
             },
             Err(e) => return Err(e),
         }
@@ -513,30 +635,16 @@ impl Driver for MidiBridgeDriver {
             Ok(_) => {},
             Err(e) if self.optional => {
                 warn!("MIDI Bridge IN open failed (optional): {}", e);
-                // Spawn background reconnection task
-                let self_clone = Self {
-                    name: self.name.clone(),
-                    to_port: self.to_port.clone(),
-                    from_port: self.from_port.clone(),
-                    filter: self.filter.clone(),
-                    transform: self.transform.clone(),
-                    optional: self.optional,
-                    midi_out: self.midi_out.clone(),
-                    midi_in: self.midi_in.clone(),
-                    feedback_callback: self.feedback_callback.clone(),
-                    status_callbacks: self.status_callbacks.clone(),
-                    current_status: self.current_status.clone(),
-                    activity_tracker: self.activity_tracker.clone(),
-                    reconnect_count_out: self.reconnect_count_out.clone(),
-                    reconnect_count_in: self.reconnect_count_in.clone(),
-                    shutdown_flag: self.shutdown_flag.clone(),
-                };
-                tokio::spawn(async move {
-                    self_clone.schedule_in_reconnect().await;
-                });
+                self.spawn_in_reconnect();
             },
             Err(e) => return Err(e),
         }
+
+        // Start the port-health monitor so a later *silent* disconnect (the
+        // input callback going dead, or the output port vanishing without a
+        // send to notice) is detected and recovered instead of going
+        // permanently dark.
+        self.spawn_health_monitor();
 
         debug!(
             "MIDI Bridge active: '{}' ⇄ '{}'",

--- a/src/drivers/obs/actions.rs
+++ b/src/drivers/obs/actions.rs
@@ -407,6 +407,15 @@ impl Driver for ObsDriver {
         self.analog_rates.write().clear();
         self.analog_error_count.write().clear();
 
+        // Clear subscriber registries. These Vecs are push-only and the OBS
+        // driver is a process-lifetime singleton, so without this each
+        // unregister→re-register cycle (a profile switch that drops then
+        // re-adds OBS) would append another indicator + status callback —
+        // duplicating event fan-out and slowly leaking. Re-registration
+        // re-subscribes a fresh callback.
+        self.indicator_emitters.write().clear();
+        self.status_callbacks.write().clear();
+
         if let Some(client) = self.client.write().await.take() {
             drop(client); // Close the connection
         }

--- a/src/drivers/obs/actions.rs
+++ b/src/drivers/obs/actions.rs
@@ -216,14 +216,19 @@ impl Driver for ObsDriver {
                     .and_then(|v| v.as_str())
                     .context("Scene name required")?;
 
-                let target = if *self.studio_mode.read() {
-                    "Preview"
-                } else {
-                    "Program"
+                // Optional 2nd param forces the destination: "program" or
+                // "preview". Absent → studio-mode default (preview if studio
+                // mode is on, else program).
+                let explicit_target = params.get(1).and_then(|v| v.as_str());
+                let target = match explicit_target {
+                    Some("preview") => "Preview",
+                    Some("program") => "Program",
+                    _ if *self.studio_mode.read() => "Preview",
+                    _ => "Program",
                 };
                 info!("OBS {} scene change -> '{}'", target, scene_name);
 
-                self.set_scene_for_mode(scene_name).await?;
+                self.set_scene_for_mode(scene_name, explicit_target).await?;
                 Ok(())
             },
 

--- a/src/drivers/obs/analog.rs
+++ b/src/drivers/obs/analog.rs
@@ -3,6 +3,7 @@
 //! Handles velocity-based pan/zoom control using gamepad analog sticks.
 //! Applies gamma curves for finer control and manages a 60Hz timer for smooth motion.
 
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::{interval, MissedTickBehavior};
@@ -125,10 +126,17 @@ impl ObsDriver {
         *active = true;
         *self.last_analog_tick.lock() = Instant::now();
 
+        // Claim a new generation. A previously-running task that briefly set
+        // `timer_active=false` (rates emptied) right before this re-arm would
+        // otherwise survive and double the tick rate; the generation mismatch
+        // makes it exit instead.
+        let my_generation = self.analog_timer_generation.fetch_add(1, Ordering::AcqRel) + 1;
+
         // Spawn timer task
         let rates = Arc::clone(&self.analog_rates);
         let last_tick = Arc::clone(&self.last_analog_tick);
         let timer_active = Arc::clone(&self.analog_timer_active);
+        let timer_generation = Arc::clone(&self.analog_timer_generation);
         let shutdown_flag = Arc::clone(&self.shutdown_flag);
         let driver_self = Arc::new(self.clone_for_task());
 
@@ -151,6 +159,13 @@ impl ObsDriver {
                 // Check if timer should stop
                 if !*timer_active.lock() {
                     debug!("OBS analog timer stopped");
+                    break;
+                }
+
+                // A newer timer task superseded this one — exit to avoid
+                // running two 60 Hz loops applying duplicate deltas.
+                if timer_generation.load(Ordering::Acquire) != my_generation {
+                    debug!("OBS analog timer stopped (superseded)");
                     break;
                 }
 

--- a/src/drivers/obs/catalog.rs
+++ b/src/drivers/obs/catalog.rs
@@ -12,15 +12,16 @@ use serde_json::json;
 pub fn obs_catalog() -> Vec<ActionDescriptor> {
     vec![
         ActionDescriptor::simple("changeScene", "Change scene")
-            .with_description("Switch program (or preview when in studio mode) to the given scene.")
-            .with_param(
-                ParamDescriptor::new("scene", ParamKind::SceneRef).with_picker("obs.scene"),
-            ),
+            .with_description(
+                "Switch to the given scene. Optional `target` forces \"program\" or \"preview\"; \
+                 when omitted, follows studio mode (preview if on, else program).",
+            )
+            .with_param(ParamDescriptor::new("scene", ParamKind::SceneRef).with_picker("obs.scene"))
+            .with_param(ParamDescriptor::new("target", ParamKind::String)),
         ActionDescriptor::simple("setScene", "Set scene (alias)")
             .with_description("Identical to changeScene; kept for legacy YAML.")
-            .with_param(
-                ParamDescriptor::new("scene", ParamKind::SceneRef).with_picker("obs.scene"),
-            ),
+            .with_param(ParamDescriptor::new("scene", ParamKind::SceneRef).with_picker("obs.scene"))
+            .with_param(ParamDescriptor::new("target", ParamKind::String)),
         ActionDescriptor::simple("toggleStudioMode", "Toggle studio mode"),
         ActionDescriptor::simple("TriggerStudioModeTransition", "Trigger studio transition"),
         ActionDescriptor::simple("nudgeX", "Nudge X (pan)")

--- a/src/drivers/obs/connection.rs
+++ b/src/drivers/obs/connection.rs
@@ -39,10 +39,12 @@ impl ObsDriver {
         Ok(guard)
     }
 
-    /// Set the active scene, respecting studio mode
+    /// Set the active scene.
     ///
-    /// In studio mode, this sets the preview scene.
-    /// In normal mode, this sets the program scene.
+    /// `explicit_target` forces the destination: `Some("program")` always sets
+    /// the program scene, `Some("preview")` always the preview scene. When
+    /// `None` (or any other value), falls back to the studio-mode default:
+    /// preview while studio mode is on, program otherwise.
     ///
     /// This consolidates the repeated pattern:
     /// ```ignore
@@ -53,14 +55,22 @@ impl ObsDriver {
     ///     client.scenes().set_current_program_scene(scene).await?;
     /// }
     /// ```
-    pub(super) async fn set_scene_for_mode(&self, scene_name: &str) -> Result<()> {
+    pub(super) async fn set_scene_for_mode(
+        &self,
+        scene_name: &str,
+        explicit_target: Option<&str>,
+    ) -> Result<()> {
         let guard = self.get_connected_client().await?;
         let client = guard
             .as_ref()
             .context("BUG: get_connected_client returned None")?;
 
-        let studio_mode = *self.studio_mode.read();
-        if studio_mode {
+        let use_preview = match explicit_target {
+            Some("preview") => true,
+            Some("program") => false,
+            _ => *self.studio_mode.read(),
+        };
+        if use_preview {
             client
                 .scenes()
                 .set_current_preview_scene(scene_name)

--- a/src/drivers/obs/driver.rs
+++ b/src/drivers/obs/driver.rs
@@ -5,7 +5,7 @@
 use obws::Client as ObsClient;
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
@@ -69,6 +69,11 @@ pub struct ObsDriver {
     // Analog motion state (velocity-based for gamepad)
     pub(super) analog_rates: Arc<parking_lot::RwLock<HashMap<String, AnalogRate>>>,
     pub(super) analog_timer_active: Arc<Mutex<bool>>,
+    /// Generation counter for the 60 Hz analog timer task. Bumped when a new
+    /// timer is spawned; a lingering older task whose captured generation no
+    /// longer matches exits, preventing two timers from a spawn racing the
+    /// old task's self-stop.
+    pub(super) analog_timer_generation: Arc<AtomicU64>,
     pub(super) last_analog_tick: Arc<Mutex<Instant>>,
 
     // Error tracking to prevent infinite retry loops
@@ -120,6 +125,7 @@ impl ObsDriver {
             // Analog motion state
             analog_rates: Arc::new(parking_lot::RwLock::new(HashMap::new())),
             analog_timer_active: Arc::new(Mutex::new(false)),
+            analog_timer_generation: Arc::new(AtomicU64::new(0)),
             last_analog_tick: Arc::new(Mutex::new(Instant::now())),
             // Error tracking
             analog_error_count: Arc::new(parking_lot::RwLock::new(HashMap::new())),
@@ -207,6 +213,7 @@ impl ObsDriver {
             analog_gamma: Arc::clone(&self.analog_gamma),
             analog_rates: Arc::clone(&self.analog_rates),
             analog_timer_active: Arc::clone(&self.analog_timer_active),
+            analog_timer_generation: Arc::clone(&self.analog_timer_generation),
             last_analog_tick: Arc::clone(&self.last_analog_tick),
             analog_error_count: Arc::clone(&self.analog_error_count),
             encoder_tracker: Arc::clone(&self.encoder_tracker),

--- a/src/drivers/obs/split_mode.rs
+++ b/src/drivers/obs/split_mode.rs
@@ -61,8 +61,8 @@ impl ObsDriver {
 
         info!("OBS: Enter split '{}' -> scene '{}'", side, split_scene);
 
-        // Switch to split scene
-        self.set_scene_for_mode(&split_scene).await?;
+        // Switch to split scene (studio-mode default routing)
+        self.set_scene_for_mode(&split_scene, None).await?;
 
         // Update state BEFORE setting camera (so state is updated even if camera fails)
         {
@@ -144,8 +144,8 @@ impl ObsDriver {
             target_camera, camera_scene
         );
 
-        // Switch to full scene
-        self.set_scene_for_mode(&camera_scene).await?;
+        // Switch to full scene (studio-mode default routing)
+        self.set_scene_for_mode(&camera_scene, None).await?;
 
         // Update state
         {

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -1077,6 +1077,8 @@ mod auto_strip_tests {
             midi: None,
             indicator: None,
             overlay: None,
+            also: None,
+            toggle: None,
         }
     }
 

--- a/src/drivers/winaudio/mod.rs
+++ b/src/drivers/winaudio/mod.rs
@@ -94,6 +94,11 @@ pub struct WinAudioDriver {
     /// per MIDI event. Refreshed by `refresh_pinned_lc` on init and on
     /// every config-touching path (`sync()`, etc.).
     pinned_lc_cache: Arc<ArcSwap<HashSet<String>>>,
+    /// Signals the page-watcher task to stop. `shutdown()` sends `true`; the
+    /// watcher selects on it so an unregistered (profile-switched-away)
+    /// driver instance doesn't leak an immortal task that keeps doing LCD
+    /// renders. A `watch` channel latches, so the signal can't be missed.
+    page_watcher_shutdown: tokio::sync::watch::Sender<bool>,
     #[cfg(target_os = "windows")]
     com: Arc<RwLock<Option<com_thread::ComThreadHandle>>>,
 }
@@ -109,6 +114,7 @@ impl WinAudioDriver {
             feedback_tx: Arc::new(RwLock::new(None)),
             discovery: Arc::new(RwLock::new(mapping::DiscoveryState::default())),
             pinned_lc_cache: Arc::new(ArcSwap::from_pointee(pinned_lc)),
+            page_watcher_shutdown: tokio::sync::watch::channel(false).0,
             #[cfg(target_os = "windows")]
             com: Arc::new(RwLock::new(None)),
         }
@@ -295,6 +301,9 @@ impl Driver for WinAudioDriver {
 
     async fn shutdown(&self) -> Result<()> {
         self.initialized.store(false, Ordering::Release);
+        // Stop the page-watcher task (otherwise it outlives this driver
+        // instance on a profile switch and keeps rendering LCD updates).
+        let _ = self.page_watcher_shutdown.send(true);
         #[cfg(target_os = "windows")]
         {
             if let Some(handle) = self.com.write().await.take() {
@@ -438,6 +447,7 @@ impl WinAudioDriver {
             return;
         };
         let mut rx = live_tx.subscribe();
+        let mut shutdown_rx = self.page_watcher_shutdown.subscribe();
         #[cfg(target_os = "windows")]
         let com = self.com.clone();
         let config = self.config.clone();
@@ -446,27 +456,50 @@ impl WinAudioDriver {
         let router_for_render = self.router.clone();
         let led_tx = self.led_tx.clone();
         tokio::spawn(async move {
-            while let Ok(event) = rx.recv().await {
-                let crate::event_bus::LiveEvent::PageChanged { index, .. } = event else {
-                    continue;
-                };
-                if !page_eligible_at_index(&router_for_render, index).await {
-                    continue;
+            loop {
+                tokio::select! {
+                    changed = shutdown_rx.changed() => {
+                        // Sender dropped, or signalled true → stop the watcher.
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                    recv = rx.recv() => {
+                        let event = match recv {
+                            Ok(ev) => ev,
+                            // A `Lagged` is recoverable: skip the missed events
+                            // and keep watching. Treating it as terminal (the
+                            // old `while let Ok`) made a long fader sweep
+                            // silently kill winaudio page syncing.
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                warn!("WinAudio page watcher lagged {} live events; continuing", n);
+                                continue;
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        };
+                        let crate::event_bus::LiveEvent::PageChanged { index, .. } = event else {
+                            continue;
+                        };
+                        if !page_eligible_at_index(&router_for_render, index).await {
+                            continue;
+                        }
+                        debug!("WinAudio: page activated, refreshing master + sessions");
+                        #[cfg(target_os = "windows")]
+                        {
+                            refresh_full_state(&com, &pinned_lc_cache, &discovery).await;
+                        }
+                        render_lcd_if_active(
+                            &router_for_render,
+                            &led_tx,
+                            &config,
+                            &pinned_lc_cache,
+                            &discovery,
+                        )
+                        .await;
+                    }
                 }
-                debug!("WinAudio: page activated, refreshing master + sessions");
-                #[cfg(target_os = "windows")]
-                {
-                    refresh_full_state(&com, &pinned_lc_cache, &discovery).await;
-                }
-                render_lcd_if_active(
-                    &router_for_render,
-                    &led_tx,
-                    &config,
-                    &pinned_lc_cache,
-                    &discovery,
-                )
-                .await;
             }
+            debug!("WinAudio page watcher stopped");
         });
     }
 

--- a/src/input/gamepad/xinput_convert.rs
+++ b/src/input/gamepad/xinput_convert.rs
@@ -4,7 +4,10 @@
 //! ensuring consistency with gilrs-based events.
 
 use super::hybrid_provider::GamepadEvent;
-use super::normalize::normalize_stick_radial;
+use super::normalize::{
+    normalize_stick_radial, XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE,
+    XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE, XINPUT_GAMEPAD_TRIGGER_THRESHOLD,
+};
 use crate::config::AnalogConfig;
 use rusty_xinput::{XInputHandle, XInputState, XInputUsageError};
 
@@ -106,6 +109,18 @@ pub fn convert_xinput_buttons(
     events
 }
 
+/// Map a raw XInput trigger (0-255) to the -1.0..1.0 axis convention used by
+/// the rest of the pipeline, flooring sub-threshold values to 0 so an idle
+/// trigger's analog jitter can't emit a fresh event on every poll (#75).
+fn trigger_axis(raw: u8) -> f32 {
+    let v = if raw < XINPUT_GAMEPAD_TRIGGER_THRESHOLD {
+        0
+    } else {
+        raw
+    };
+    (v as f32 / 255.0) * 2.0 - 1.0
+}
+
 /// Convert XInput analog axes to GamepadEvents
 ///
 /// Compares old and new axis values and emits events for changed axes.
@@ -122,34 +137,38 @@ pub fn convert_xinput_axes(
 ) -> Vec<GamepadEvent> {
     let mut events = Vec::new();
 
-    // Normalize sticks with radial deadzone (circular, not square)
-    // XInput API spec recommends deadzone of 7849 for sticks
-    const DEADZONE: f32 = 7849.0;
+    // Normalize sticks with radial deadzone (circular, not square).
+    // XInput spec: left stick 7849, right stick 8689 (right is larger).
+    // Using the left value for both let right-stick rest noise in the
+    // 7849..8689 band leak through as a continuous rx/ry event flood (#75).
+    const LEFT_DEADZONE: f32 = XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE as f32;
+    const RIGHT_DEADZONE: f32 = XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE as f32;
 
     let (lx, ly) = normalize_stick_radial(
         new_state.raw.Gamepad.sThumbLX,
         new_state.raw.Gamepad.sThumbLY,
-        DEADZONE,
+        LEFT_DEADZONE,
     );
     let (rx, ry) = normalize_stick_radial(
         new_state.raw.Gamepad.sThumbRX,
         new_state.raw.Gamepad.sThumbRY,
-        DEADZONE,
+        RIGHT_DEADZONE,
     );
 
-    // Normalize triggers (u8 0-255 → f32 -1.0 to 1.0)
-    // Note: We map to full -1..1 range to match axis convention
-    let lt = (new_state.left_trigger() as f32 / 255.0) * 2.0 - 1.0;
-    let rt = (new_state.right_trigger() as f32 / 255.0) * 2.0 - 1.0;
+    // Triggers (u8 0-255 → f32 -1.0..1.0). Floor sub-threshold jitter to 0
+    // first so an idle, slightly-noisy trigger doesn't emit a fresh event on
+    // every 16 ms poll (#75 flood). The -1..1 mapping range is unchanged.
+    let lt = trigger_axis(new_state.left_trigger());
+    let rt = trigger_axis(new_state.right_trigger());
 
     // Build axis list with change detection
     // Note: old_state values also need radial normalization for accurate change detection
     let (old_lx, old_ly) = old_state
-        .map(|s| normalize_stick_radial(s.thumb_lx, s.thumb_ly, DEADZONE))
+        .map(|s| normalize_stick_radial(s.thumb_lx, s.thumb_ly, LEFT_DEADZONE))
         .unwrap_or((0.0, 0.0));
 
     let (old_rx, old_ry) = old_state
-        .map(|s| normalize_stick_radial(s.thumb_rx, s.thumb_ry, DEADZONE))
+        .map(|s| normalize_stick_radial(s.thumb_rx, s.thumb_ry, RIGHT_DEADZONE))
         .unwrap_or((0.0, 0.0));
 
     let axes = [
@@ -157,16 +176,8 @@ pub fn convert_xinput_axes(
         ("ly", -ly, old_state.map(|_| -old_ly)), // Invert Y
         ("rx", rx, old_state.map(|_| old_rx)),
         ("ry", -ry, old_state.map(|_| -old_ry)), // Invert Y
-        (
-            "zl",
-            lt,
-            old_state.map(|s| (s.left_trigger as f32 / 255.0) * 2.0 - 1.0),
-        ),
-        (
-            "zr",
-            rt,
-            old_state.map(|s| (s.right_trigger as f32 / 255.0) * 2.0 - 1.0),
-        ),
+        ("zl", lt, old_state.map(|s| trigger_axis(s.left_trigger))),
+        ("zr", rt, old_state.map(|s| trigger_axis(s.right_trigger))),
     ];
 
     for (axis_name, new_value, old_value) in axes {

--- a/src/router/feedback.rs
+++ b/src/router/feedback.rs
@@ -234,6 +234,12 @@ impl super::Router {
             },
         };
 
+        // Feedback-driven toggles: react to the app's *real* on/off state BEFORE
+        // anti-echo. Anti-echo only guards re-sending our own values to the
+        // surface; a toggle is a semantic reaction to the app's reported state
+        // and must see all feedback. Edge detection keeps it idempotent.
+        self.evaluate_feedback_toggles(app_key, &entry).await;
+
         // BUG-001 FIX: Check anti-echo BEFORE updating state (now async)
         // If this is an echo of a value we recently sent, suppress it entirely
         if self

--- a/src/router/feedback_toggle.rs
+++ b/src/router/feedback_toggle.rs
@@ -68,14 +68,22 @@ impl super::Router {
                 continue;
             }
 
-            let prev = self.toggle_states.read().await.get(&control_id).copied();
+            // Atomic read-compare-update under a single write lock: if two
+            // feedback messages for the same control_id are ever processed
+            // concurrently, only the first observes the transition and inserts —
+            // the second sees the already-updated state and no-ops, so the edge
+            // action can't double-fire. Dispatch happens after the lock is released.
+            let prev = {
+                let mut states = self.toggle_states.write().await;
+                let prev = states.get(&control_id).copied();
+                if prev != Some(now_on) {
+                    states.insert(control_id.clone(), now_on);
+                }
+                prev
+            };
             if prev == Some(now_on) {
                 continue; // No change → idempotent no-op.
             }
-            self.toggle_states
-                .write()
-                .await
-                .insert(control_id.clone(), now_on);
 
             // First observation: record the state without firing, so connecting
             // (or a config reload) never triggers an unexpected action.

--- a/src/router/feedback_toggle.rs
+++ b/src/router/feedback_toggle.rs
@@ -1,0 +1,187 @@
+//! Feedback-driven toggle evaluation.
+//!
+//! A `toggle` on a control fires driver actions when an app's *real* feedback
+//! state transitions on/off (e.g. the Voicemeeter record LED), as opposed to
+//! firing on the X-Touch button press like `action`/`also` do.
+//!
+//! The trigger is detected in [`Router::on_midi_from_app`] (the page-independent
+//! feedback entry point). Edge detection against [`Router::toggle_states`] makes
+//! firing idempotent: a repeated identical state never re-triggers, and the very
+//! first observation only records the state (no spurious action on connect).
+
+use std::collections::HashMap;
+
+use tracing::{debug, warn};
+
+use crate::config::{ControlMapping, MidiType, ToggleConfig};
+use crate::control_mapping::{load_default_mappings, MidiSpec as HwMidiSpec};
+use crate::state::{MidiStateEntry, MidiStatus};
+
+/// Synthetic Note-On (velocity 127) used to dispatch toggle steps as a "press".
+///
+/// `dispatch_step` filters button releases and OBS ignores trigger actions on
+/// release (`ExecutionContext::is_button_release`), so the steps must look like
+/// a press. The note byte is irrelevant for driver actions.
+const SYNTHETIC_PRESS: [u8; 3] = [0x90, 0x00, 0x7F];
+
+impl super::Router {
+    /// React to an app feedback `entry` by firing any matching toggle's
+    /// `on`/`off` steps on a state transition.
+    ///
+    /// Called from `on_midi_from_app` *before* anti-echo suppression: the toggle
+    /// is a semantic reaction to the app's reported state, distinct from the
+    /// anti-echo concern of not bouncing our own values back to the surface.
+    pub(crate) async fn evaluate_feedback_toggles(&self, app_key: &str, entry: &MidiStateEntry) {
+        // Snapshot the toggles whose source matches this app, then drop the
+        // config lock before dispatching (dispatch_step re-reads config/drivers).
+        let (toggles, is_mcu) = {
+            let config = self.config.read().await;
+            let is_mcu = config.is_mcu_mode();
+            let active_idx = *self.active_page_index.read().await;
+
+            let mut collected: Vec<(String, ToggleConfig)> = Vec::new();
+
+            // Global controls first (the primary use case is a global toggle),
+            // then the active page's controls.
+            if let Some(global) = &config.pages_global {
+                if let Some(controls) = &global.controls {
+                    collect_toggles(controls, app_key, &mut collected);
+                }
+            }
+            if let Some(page) = config.pages.get(active_idx) {
+                if let Some(controls) = &page.controls {
+                    collect_toggles(controls, app_key, &mut collected);
+                }
+            }
+
+            (collected, is_mcu)
+        };
+
+        if toggles.is_empty() {
+            return;
+        }
+
+        let now_on = entry.value.as_number().map(|n| n > 0).unwrap_or(false);
+
+        for (control_id, toggle) in toggles {
+            if !toggle_matches(&control_id, &toggle, entry, is_mcu) {
+                continue;
+            }
+
+            let prev = self.toggle_states.read().await.get(&control_id).copied();
+            if prev == Some(now_on) {
+                continue; // No change → idempotent no-op.
+            }
+            self.toggle_states
+                .write()
+                .await
+                .insert(control_id.clone(), now_on);
+
+            // First observation: record the state without firing, so connecting
+            // (or a config reload) never triggers an unexpected action.
+            if prev.is_none() {
+                debug!(
+                    "Toggle '{}': initial state recorded ({})",
+                    control_id,
+                    if now_on { "on" } else { "off" }
+                );
+                continue;
+            }
+
+            let steps = if now_on { &toggle.on } else { &toggle.off };
+            if steps.is_empty() {
+                continue;
+            }
+            debug!(
+                "Toggle '{}': {} → dispatching {} step(s)",
+                control_id,
+                if now_on { "ON" } else { "OFF" },
+                steps.len()
+            );
+
+            for step in steps {
+                if step.midi.is_some() {
+                    warn!(
+                        "Toggle '{}': `midi` steps unsupported (synthetic trigger), skipping",
+                        control_id
+                    );
+                    continue;
+                }
+                self.dispatch_step(&SYNTHETIC_PRESS, &control_id, step)
+                    .await;
+            }
+        }
+    }
+}
+
+/// Collect `(control_id, toggle)` pairs whose effective source matches `app_key`.
+fn collect_toggles(
+    controls: &HashMap<String, ControlMapping>,
+    app_key: &str,
+    out: &mut Vec<(String, ToggleConfig)>,
+) {
+    for (id, mapping) in controls {
+        if let Some(toggle) = &mapping.toggle {
+            let source = toggle.source.as_deref().unwrap_or(mapping.app.as_str());
+            if source == app_key {
+                out.push((id.clone(), toggle.clone()));
+            }
+        }
+    }
+}
+
+/// Does `entry` match the address watched by `toggle` for `control_id`?
+///
+/// Uses the explicit `watch` spec when present, otherwise derives the watched
+/// address from the control's own hardware mapping (e.g. `record` → Note 95 in
+/// MCU mode), which a feedback echo of that button would carry.
+fn toggle_matches(
+    control_id: &str,
+    toggle: &ToggleConfig,
+    entry: &MidiStateEntry,
+    is_mcu: bool,
+) -> bool {
+    if let Some(watch) = &toggle.watch {
+        // Channel is matched only when the watch spec pins one (MidiSpec channel
+        // is 1-based, same as MidiAddr::channel).
+        let channel_ok = watch
+            .channel
+            .map(|c| entry.addr.channel == Some(c))
+            .unwrap_or(true);
+        return match watch.midi_type {
+            MidiType::Note => {
+                entry.addr.status == MidiStatus::Note
+                    && watch
+                        .note
+                        .map(|n| entry.addr.data1 == Some(n))
+                        .unwrap_or(false)
+                    && channel_ok
+            },
+            MidiType::Cc => {
+                entry.addr.status == MidiStatus::CC
+                    && watch
+                        .cc
+                        .map(|c| entry.addr.data1 == Some(c))
+                        .unwrap_or(false)
+                    && channel_ok
+            },
+            MidiType::Pb => entry.addr.status == MidiStatus::PB && channel_ok,
+            MidiType::Passthrough => false,
+        };
+    }
+
+    // Default: derive from the control's hardware address.
+    match load_default_mappings()
+        .ok()
+        .and_then(|db| db.get_midi_spec(control_id, is_mcu))
+    {
+        Some(HwMidiSpec::Note { note }) => {
+            entry.addr.status == MidiStatus::Note && entry.addr.data1 == Some(note)
+        },
+        Some(HwMidiSpec::ControlChange { cc }) => {
+            entry.addr.status == MidiStatus::CC && entry.addr.data1 == Some(cc)
+        },
+        Some(HwMidiSpec::PitchBend { .. }) => entry.addr.status == MidiStatus::PB,
+        None => false,
+    }
+}

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -98,11 +98,17 @@ impl Router {
         // Spawn state actor with persistence channel
         let state_actor = StateActorHandle::spawn(persistence_actor.cmd_tx());
 
-        // Open sled database for camera target state (separate db to avoid lock conflicts)
+        // Open sled database for camera target state (separate db to avoid lock conflicts).
+        // Cap the page cache — sled's default is 1 GiB, 20x this project's whole
+        // RAM budget; this DB is tiny so the cap is never reached in practice.
         let camera_db_path = format!("{}_camera", db_path);
-        let camera_db = sled::open(&camera_db_path).with_context(|| {
-            format!("Failed to open camera sled database at: {}", camera_db_path)
-        })?;
+        let camera_db = sled::Config::new()
+            .path(&camera_db_path)
+            .cache_capacity(crate::state::persistence_actor::SLED_CACHE_CAPACITY_BYTES)
+            .open()
+            .with_context(|| {
+                format!("Failed to open camera sled database at: {}", camera_db_path)
+            })?;
         let camera_targets = Arc::new(CameraTargetState::new(camera_db));
 
         Ok(Self {
@@ -275,6 +281,16 @@ impl Router {
     pub async fn save_state_snapshot(&self) -> Result<()> {
         use crate::state::{AppKey, StateSnapshot};
 
+        // If the StateActor has died, `list_states_for_apps` returns an empty
+        // map. Persisting that would overwrite the on-disk snapshot with
+        // nothing, destroying recoverable state — skip the save instead.
+        if !self.state_actor.is_alive() {
+            tracing::warn!(
+                "StateActor not alive — skipping snapshot save to avoid erasing persisted state"
+            );
+            return Ok(());
+        }
+
         // Collect states from all apps
         let all_apps: Vec<AppKey> = AppKey::all().to_vec();
         let states = self.state_actor.list_states_for_apps(all_apps).await;
@@ -313,7 +329,7 @@ impl Router {
         let dropped = self.unregister_drivers_not_in(&new_referenced).await;
         for name in dropped {
             match crate::state::AppKey::from_str(&name) {
-                Some(app_key) => self.state_actor.clear_states_for_app(app_key),
+                Some(app_key) => self.state_actor.clear_states_for_app(app_key).await,
                 None => warn!(
                     "Skipping state purge for driver '{}' — no AppKey mapping; \
                      its app_states will not be reclaimed on this reload",
@@ -339,6 +355,13 @@ impl Router {
         }
         drop(index);
         drop(config);
+
+        // Drop feedback-toggle edge-detection state. After a profile swap the
+        // set of toggle controls (and their recorded prev on/off state) may
+        // not match the new config; clearing lets the "first observation only
+        // records" rule re-establish state without a spurious fire, and stops
+        // the map retaining control_ids that no longer exist.
+        self.toggle_states.write().await.clear();
 
         // Notify all drivers to sync with new config
         let drivers = self.drivers.read().await;

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -11,6 +11,7 @@ mod anti_echo;
 mod camera_target;
 mod driver;
 mod feedback;
+mod feedback_toggle;
 mod indicators;
 mod page;
 mod refresh;
@@ -71,6 +72,11 @@ pub struct Router {
     /// the main event loop to flush pending MIDI / display updates. The
     /// X-Touch input arm does this inline after `on_midi_from_xtouch`.
     pub display_refresh_notify: Arc<tokio::sync::Notify>,
+    /// Last known on/off state per feedback-driven toggle control (keyed by
+    /// `control_id`). Used for edge detection so a toggle fires only on an
+    /// actual transition, not on every repeated feedback message. See
+    /// `feedback_toggle.rs`.
+    pub(crate) toggle_states: Arc<RwLock<HashMap<String, bool>>>,
 }
 
 impl Router {
@@ -114,6 +120,7 @@ impl Router {
             camera_targets,
             live_tx: Arc::new(tokio::sync::RwLock::new(None)),
             display_refresh_notify: Arc::new(tokio::sync::Notify::new()),
+            toggle_states: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 

--- a/src/router/page.rs
+++ b/src/router/page.rs
@@ -74,8 +74,17 @@ impl super::Router {
         // Try parsing as index first
         if let Ok(index) = name_or_index.parse::<usize>() {
             if index < config.pages.len() {
+                // Read the name from the guard we already hold. Calling
+                // get_active_page_name() here would re-acquire config.read()
+                // while this read guard is still live; on tokio's fair RwLock
+                // a writer queued between the two reads (config hot-reload)
+                // deadlocks both tasks — and the whole main loop with them.
+                let page_name = config
+                    .pages
+                    .get(index)
+                    .map(|p| p.name.clone())
+                    .unwrap_or_else(|| "(none)".to_string());
                 *self.active_page_index.write().await = index;
-                let page_name = self.get_active_page_name().await;
                 info!("Active page: {}", page_name);
                 drop(config); // Release lock before refresh
                 self.refresh_page().await;
@@ -91,8 +100,10 @@ impl super::Router {
             .iter()
             .position(|p| p.name.eq_ignore_ascii_case(name_or_index))
         {
+            // See the index branch above: derive the name from the held guard,
+            // never via a re-entrant config.read().
+            let page_name = config.pages[index].name.clone();
             *self.active_page_index.write().await = index;
-            let page_name = self.get_active_page_name().await;
             info!("Active page: {}", page_name);
             drop(config); // Release lock before refresh
             self.refresh_page().await;

--- a/src/router/refresh.rs
+++ b/src/router/refresh.rs
@@ -26,8 +26,10 @@ impl super::Router {
 
         debug!("Refreshing page '{}' (epoch={})", page.name, new_epoch);
 
-        // Clear X-Touch shadow state to allow re-emission (fire-and-forget)
-        self.state_actor.clear_shadows();
+        // Clear X-Touch shadow state to allow re-emission. Awaited so the
+        // clear can't be dropped under burst (it would otherwise let anti-echo
+        // suppress this refresh's own re-emitted values).
+        self.state_actor.clear_shadows().await;
 
         // Build and execute refresh plan
         let entries = self.plan_page_refresh(&page).await;

--- a/src/router/tests.rs
+++ b/src/router/tests.rs
@@ -157,6 +157,8 @@ async fn test_midi_note_off_does_not_double_fire_driver_action() {
             midi: None,
             overlay: None,
             indicator: None,
+            also: None,
+            toggle: None,
         },
     );
     page.controls = Some(controls);
@@ -298,6 +300,8 @@ async fn test_driver_execution_with_context() {
             midi: None,
             overlay: None,
             indicator: None,
+            also: None,
+            toggle: None,
         },
     );
     page.controls = Some(controls);
@@ -335,6 +339,8 @@ async fn test_driver_execution_missing_driver() {
             midi: None,
             overlay: None,
             indicator: None,
+            also: None,
+            toggle: None,
         },
     );
     page.controls = Some(controls);
@@ -393,6 +399,8 @@ async fn test_multiple_drivers_execution() {
             midi: None,
             overlay: None,
             indicator: None,
+            also: None,
+            toggle: None,
         },
     );
 
@@ -405,6 +413,8 @@ async fn test_multiple_drivers_execution() {
             midi: None,
             overlay: None,
             indicator: None,
+            also: None,
+            toggle: None,
         },
     );
 
@@ -626,6 +636,8 @@ async fn test_update_config_unregisters_drivers_removed_from_new_config() {
             midi: None,
             overlay: None,
             indicator: None,
+            also: None,
+            toggle: None,
         },
     );
     control_a.insert(
@@ -637,6 +649,8 @@ async fn test_update_config_unregisters_drivers_removed_from_new_config() {
             midi: None,
             overlay: None,
             indicator: None,
+            also: None,
+            toggle: None,
         },
     );
     let mut page_a = make_test_page("AB");
@@ -668,6 +682,8 @@ async fn test_update_config_unregisters_drivers_removed_from_new_config() {
             midi: None,
             overlay: None,
             indicator: None,
+            also: None,
+            toggle: None,
         },
     );
     let mut page_b = make_test_page("B");
@@ -708,4 +724,311 @@ async fn test_unregister_drivers_not_in_is_idempotent() {
         "nothing to remove on second call (idempotent)"
     );
     assert_eq!(router.list_drivers().await, vec!["obs".to_string()]);
+}
+
+// ===== Multi-action buttons (`also`) =====
+
+/// A control with `also` must fan out to its primary effect AND every extra
+/// step. Action steps fire on press only (release filtered); MIDI direct steps
+/// fire on both edges (press + release). Mirrors the real Record button:
+/// passthrough primary + OBS `selectCamera` (action) + QLC CC (midi).
+///
+/// mute1 in MCU mode is note=16 (see docs/xtouch-matching.csv), outside the
+/// paging note ranges, so it falls through to the driver/MIDI dispatch path.
+#[tokio::test]
+async fn test_multi_action_also_fans_out_press_and_release_semantics() {
+    use crate::config::{ActionStep, MidiSpec, MidiType};
+
+    let mut page = make_test_page("Page 1");
+    let mut controls = HashMap::new();
+    controls.insert(
+        "mute1".to_string(),
+        ControlMapping {
+            app: "primary".to_string(),
+            action: Some("trigger".to_string()),
+            params: None,
+            midi: None,
+            overlay: None,
+            indicator: None,
+            also: Some(vec![
+                // Action step (OBS-like) → press-only.
+                ActionStep {
+                    app: "secondary".to_string(),
+                    action: Some("selectCamera".to_string()),
+                    params: Some(vec![json!("Main")]),
+                    midi: None,
+                },
+                // MIDI direct step (QLC-like CC) → both edges.
+                ActionStep {
+                    app: "midiapp".to_string(),
+                    action: None,
+                    params: None,
+                    midi: Some(MidiSpec {
+                        midi_type: MidiType::Cc,
+                        channel: Some(1),
+                        cc: Some(20),
+                        note: None,
+                    }),
+                },
+            ]),
+            toggle: None,
+        },
+    );
+    page.controls = Some(controls);
+
+    let config = make_test_config(vec![page]);
+    let router = make_test_router(config);
+
+    let primary = Arc::new(ConsoleDriver::new("primary"));
+    let secondary = Arc::new(ConsoleDriver::new("secondary"));
+    let midiapp = Arc::new(ConsoleDriver::new("midiapp"));
+    router
+        .register_driver("primary".to_string(), primary.clone())
+        .await
+        .unwrap();
+    router
+        .register_driver("secondary".to_string(), secondary.clone())
+        .await
+        .unwrap();
+    router
+        .register_driver("midiapp".to_string(), midiapp.clone())
+        .await
+        .unwrap();
+
+    // Press: Note On, ch1, note 16, velocity 127 → all three fire once.
+    router.on_midi_from_xtouch(&[0x90, 16, 127]).await;
+    assert_eq!(
+        primary.execution_count().await,
+        1,
+        "primary action fires on press"
+    );
+    assert_eq!(
+        secondary.execution_count().await,
+        1,
+        "also action fires on press"
+    );
+    assert_eq!(
+        midiapp.execution_count().await,
+        1,
+        "also midi fires on press"
+    );
+
+    // Release: real Note Off (0x80). Action steps must NOT re-fire; the MIDI
+    // direct step fires again (both edges → momentary CC 127/0).
+    router.on_midi_from_xtouch(&[0x80, 16, 0]).await;
+    assert_eq!(
+        primary.execution_count().await,
+        1,
+        "primary action ignores release"
+    );
+    assert_eq!(
+        secondary.execution_count().await,
+        1,
+        "also action ignores release"
+    );
+    assert_eq!(
+        midiapp.execution_count().await,
+        2,
+        "also midi fires on release too"
+    );
+}
+
+// ===== Feedback-driven toggles (`toggle`) =====
+
+use crate::config::{ActionStep, GlobalPageDefaults, MidiSpec, MidiType, ToggleConfig};
+
+/// A `record` toggle whose `on` steps target driver "obs" (selectCamera) and
+/// `off` steps target a distinct driver "obsoff" (changeScene), so a test can
+/// tell which edge fired. `watch` is left to the caller (explicit vs derived).
+fn record_toggle(watch: Option<MidiSpec>) -> ToggleConfig {
+    ToggleConfig {
+        source: Some("voicemeeter".to_string()),
+        watch,
+        on: vec![ActionStep {
+            app: "obs".to_string(),
+            action: Some("selectCamera".to_string()),
+            params: Some(vec![json!("Main"), json!("program")]),
+            midi: None,
+        }],
+        off: vec![ActionStep {
+            app: "obsoff".to_string(),
+            action: Some("changeScene".to_string()),
+            params: Some(vec![json!("End")]),
+            midi: None,
+        }],
+    }
+}
+
+/// Config with a global `record` control carrying `toggle`, plus one empty page.
+fn make_toggle_config(toggle: ToggleConfig) -> AppConfig {
+    let mut controls = HashMap::new();
+    controls.insert(
+        "record".to_string(),
+        ControlMapping {
+            app: "voicemeeter".to_string(),
+            action: None,
+            params: None,
+            midi: None,
+            overlay: None,
+            indicator: None,
+            also: None,
+            toggle: Some(toggle),
+        },
+    );
+    let mut config = make_test_config(vec![make_test_page("P1")]);
+    config.pages_global = Some(GlobalPageDefaults {
+        controls: Some(controls),
+        lcd: None,
+        passthroughs: None,
+    });
+    config
+}
+
+/// Register the `on`/`off` target drivers and return them for assertions.
+async fn register_toggle_targets(router: &Router) -> (Arc<ConsoleDriver>, Arc<ConsoleDriver>) {
+    let on_drv = Arc::new(ConsoleDriver::new("obs"));
+    let off_drv = Arc::new(ConsoleDriver::new("obsoff"));
+    router
+        .register_driver("obs".to_string(), on_drv.clone())
+        .await
+        .unwrap();
+    router
+        .register_driver("obsoff".to_string(), off_drv.clone())
+        .await
+        .unwrap();
+    (on_drv, off_drv)
+}
+
+/// Note On, ch1, note 95 (the record button's MCU address), given velocity.
+fn note95(velocity: u8) -> [u8; 3] {
+    [0x90, 95, velocity]
+}
+
+/// A toggle must fire `on` on the OFF→ON edge and `off` on the ON→OFF edge,
+/// stay silent on repeated identical states, and never fire on the first
+/// (baseline) observation.
+#[tokio::test]
+async fn test_feedback_toggle_fires_on_state_transitions() {
+    let watch = Some(MidiSpec {
+        midi_type: MidiType::Note,
+        channel: Some(1),
+        cc: None,
+        note: Some(95),
+    });
+    let router = make_test_router(make_toggle_config(record_toggle(watch)));
+    let (on_drv, off_drv) = register_toggle_targets(&router).await;
+
+    // 1) First feedback (OFF): baseline only, no fire.
+    router
+        .on_midi_from_app("voicemeeter", &note95(0), "voicemeeter")
+        .await;
+    assert_eq!(
+        on_drv.execution_count().await,
+        0,
+        "baseline OFF must not fire"
+    );
+    assert_eq!(off_drv.execution_count().await, 0);
+
+    // 2) OFF→ON edge: `on` fires once.
+    router
+        .on_midi_from_app("voicemeeter", &note95(127), "voicemeeter")
+        .await;
+    assert_eq!(on_drv.execution_count().await, 1, "ON edge fires `on`");
+    assert_eq!(off_drv.execution_count().await, 0);
+
+    // 3) Repeated ON (different velocity, still > 0): idempotent, no re-fire.
+    router
+        .on_midi_from_app("voicemeeter", &note95(100), "voicemeeter")
+        .await;
+    assert_eq!(
+        on_drv.execution_count().await,
+        1,
+        "repeated ON must not re-fire"
+    );
+
+    // 4) ON→OFF edge: `off` fires once.
+    router
+        .on_midi_from_app("voicemeeter", &note95(0), "voicemeeter")
+        .await;
+    assert_eq!(off_drv.execution_count().await, 1, "OFF edge fires `off`");
+    assert_eq!(
+        on_drv.execution_count().await,
+        1,
+        "`on` unchanged on OFF edge"
+    );
+}
+
+/// The very first feedback only records state, even when it is ON — so
+/// connecting (or a config reload) never triggers an unexpected action.
+#[tokio::test]
+async fn test_feedback_toggle_initial_on_does_not_fire() {
+    let watch = Some(MidiSpec {
+        midi_type: MidiType::Note,
+        channel: Some(1),
+        cc: None,
+        note: Some(95),
+    });
+    let router = make_test_router(make_toggle_config(record_toggle(watch)));
+    let (on_drv, off_drv) = register_toggle_targets(&router).await;
+
+    router
+        .on_midi_from_app("voicemeeter", &note95(127), "voicemeeter")
+        .await;
+    assert_eq!(on_drv.execution_count().await, 0, "initial ON only records");
+    assert_eq!(off_drv.execution_count().await, 0);
+}
+
+/// With no explicit `watch`, the watched address is derived from the control's
+/// hardware mapping (`record` = Note 95 in MCU mode). Unrelated notes are
+/// ignored.
+#[tokio::test]
+async fn test_feedback_toggle_default_watch_uses_hardware_address() {
+    let router = make_test_router(make_toggle_config(record_toggle(None)));
+    let (on_drv, _off_drv) = register_toggle_targets(&router).await;
+
+    // Baseline OFF, then ON edge on Note 95 fires `on`.
+    router
+        .on_midi_from_app("voicemeeter", &note95(0), "voicemeeter")
+        .await;
+    router
+        .on_midi_from_app("voicemeeter", &note95(127), "voicemeeter")
+        .await;
+    assert_eq!(
+        on_drv.execution_count().await,
+        1,
+        "default-derived Note 95 watch fires on the ON edge"
+    );
+
+    // A different note is not the record address → ignored.
+    router
+        .on_midi_from_app("voicemeeter", &[0x90, 80, 127], "voicemeeter")
+        .await;
+    assert_eq!(
+        on_drv.execution_count().await,
+        1,
+        "unrelated note must not affect the toggle"
+    );
+}
+
+/// A toggle only reacts to feedback from its `source` app, not other apps.
+#[tokio::test]
+async fn test_feedback_toggle_ignores_other_source_app() {
+    let watch = Some(MidiSpec {
+        midi_type: MidiType::Note,
+        channel: Some(1),
+        cc: None,
+        note: Some(95),
+    });
+    let router = make_test_router(make_toggle_config(record_toggle(watch)));
+    let (on_drv, off_drv) = register_toggle_targets(&router).await;
+
+    // Same Note 95, but from OBS (not the toggle's source) → no effect.
+    router.on_midi_from_app("obs", &note95(0), "obs").await;
+    router.on_midi_from_app("obs", &note95(127), "obs").await;
+    assert_eq!(
+        on_drv.execution_count().await,
+        0,
+        "wrong source must not fire"
+    );
+    assert_eq!(off_drv.execution_count().await, 0);
 }

--- a/src/router/xtouch_input.rs
+++ b/src/router/xtouch_input.rs
@@ -3,7 +3,14 @@
 use crate::event_bus::{HwEventKind, LiveEvent};
 use crate::state::{build_entry_from_raw, AppKey};
 use serde_json::Value;
+use std::time::Duration;
 use tracing::{debug, trace, warn};
+
+/// Hard cap on a single driver action dispatch. The whole gateway runs on one
+/// `tokio::select!` loop; a wedged OBS WebSocket call (half-dead TCP) would
+/// otherwise block X-Touch input, faders and feedback indefinitely — the
+/// "MIDI goes dead" symptom. Local actions complete in well under this.
+const DRIVER_EXECUTE_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Classify an X-Touch MIDI message into a `HwEventKind` and a normalized
 /// `f32` value in `[0.0, 1.0]` (or 14-bit faders -> `pb / 16383.0`).
@@ -337,22 +344,32 @@ impl super::Router {
                     },
                 });
 
-                // Call passthrough action on the bridge
-                if let Err(e) = driver.execute("passthrough", vec![], ctx).await {
-                    warn!("Failed to passthrough MIDI: {}", e);
-                } else {
-                    // OPTIMISTIC UPDATE: Store the sent value in StateActor
-                    // This ensures state persists even if the app doesn't send feedback
-                    // (e.g., QLC+ doesn't echo MIDI values back)
-                    if let Some(app) = AppKey::from_str(&step.app) {
-                        if let Some(entry) = build_entry_from_raw(&bytes, &step.app) {
-                            debug!(
-                                "Optimistic state update: {} -> {:?} = {:?}",
-                                step.app, entry.addr, entry.value
-                            );
-                            self.state_actor.update_state(app, entry);
+                // Call passthrough action on the bridge (timeout-bounded)
+                match tokio::time::timeout(
+                    DRIVER_EXECUTE_TIMEOUT,
+                    driver.execute("passthrough", vec![], ctx),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {
+                        // OPTIMISTIC UPDATE: Store the sent value in StateActor
+                        // This ensures state persists even if the app doesn't send feedback
+                        // (e.g., QLC+ doesn't echo MIDI values back)
+                        if let Some(app) = AppKey::from_str(&step.app) {
+                            if let Some(entry) = build_entry_from_raw(&bytes, &step.app) {
+                                debug!(
+                                    "Optimistic state update: {} -> {:?} = {:?}",
+                                    step.app, entry.addr, entry.value
+                                );
+                                self.state_actor.update_state(app, entry);
+                            }
                         }
-                    }
+                    },
+                    Ok(Err(e)) => warn!("Failed to passthrough MIDI: {}", e),
+                    Err(_) => warn!(
+                        "Bridge '{}' passthrough timed out after {:?}",
+                        step.app, DRIVER_EXECUTE_TIMEOUT
+                    ),
                 }
             } else {
                 warn!(
@@ -451,13 +468,21 @@ impl super::Router {
             });
         }
 
-        // Execute driver action
+        // Execute driver action (timeout-bounded so a wedged driver can't
+        // freeze the single main event loop).
         debug!(
             "→ Routing: {} → app={} action={} (value={:?})",
             control_id, step.app, action, ctx.value
         );
-        if let Err(e) = driver.execute(action, params, ctx).await {
-            warn!("Driver execution failed: {}", e);
+        match tokio::time::timeout(DRIVER_EXECUTE_TIMEOUT, driver.execute(action, params, ctx))
+            .await
+        {
+            Ok(Ok(())) => {},
+            Ok(Err(e)) => warn!("Driver execution failed: {}", e),
+            Err(_) => warn!(
+                "Driver '{}' action '{}' timed out after {:?}",
+                step.app, action, DRIVER_EXECUTE_TIMEOUT
+            ),
         }
     }
 }

--- a/src/router/xtouch_input.rs
+++ b/src/router/xtouch_input.rs
@@ -210,16 +210,38 @@ impl super::Router {
         };
         drop(config);
 
-        // Check if this is MIDI direct mode (send raw MIDI to bridge)
-        if let Some(target_spec) = &control_config.midi {
-            self.handle_midi_direct_mode(raw, control_id, &control_config, target_spec)
-                .await;
-            return;
-        }
+        // Effet primaire (comportement historique du contrôle) : MIDI direct si
+        // `midi:` est présent, sinon action driver.
+        let primary = control_config.primary_step();
+        self.dispatch_step(raw, control_id, &primary).await;
 
-        // Driver action mode
-        self.handle_driver_action_mode(raw, control_id, &control_config)
-            .await;
+        // Effets supplémentaires (boutons multi-action) : chaque étape est
+        // déclenchée en plus du primaire.
+        if let Some(steps) = &control_config.also {
+            for step in steps {
+                self.dispatch_step(raw, control_id, step).await;
+            }
+        }
+    }
+
+    /// Route une étape de dispatch vers le bon handler.
+    ///
+    /// `midi:` présent → MIDI direct (passthrough/transform) ; sinon action driver.
+    ///
+    /// `pub(crate)` : réutilisé par `feedback_toggle.rs` pour déclencher les
+    /// étapes d'un toggle (avec un message MIDI synthétique).
+    pub(crate) async fn dispatch_step(
+        &self,
+        raw: &[u8],
+        control_id: &str,
+        step: &crate::config::ActionStep,
+    ) {
+        if let Some(target_spec) = &step.midi {
+            self.handle_midi_direct_mode(raw, control_id, step, target_spec)
+                .await;
+        } else {
+            self.handle_driver_action_mode(raw, control_id, step).await;
+        }
     }
 
     /// Handle MIDI direct mode (transform and send to bridge)
@@ -227,7 +249,7 @@ impl super::Router {
         &self,
         raw: &[u8],
         control_id: &str,
-        control_config: &crate::config::ControlMapping,
+        step: &crate::config::ActionStep,
         target_spec: &crate::config::MidiSpec,
     ) {
         // 1. Parse input MIDI to get normalized value (0.0 - 1.0)
@@ -295,13 +317,13 @@ impl super::Router {
                 control_id,
                 msg,
                 bytes.len(),
-                control_config.app
+                step.app
             );
 
             // Get the MIDI bridge driver for this app
             let driver = {
                 let drivers = self.drivers.read().await;
-                drivers.get(&control_config.app).cloned()
+                drivers.get(&step.app).cloned()
             };
 
             if let Some(driver) = driver {
@@ -322,11 +344,11 @@ impl super::Router {
                     // OPTIMISTIC UPDATE: Store the sent value in StateActor
                     // This ensures state persists even if the app doesn't send feedback
                     // (e.g., QLC+ doesn't echo MIDI values back)
-                    if let Some(app) = AppKey::from_str(&control_config.app) {
-                        if let Some(entry) = build_entry_from_raw(&bytes, &control_config.app) {
+                    if let Some(app) = AppKey::from_str(&step.app) {
+                        if let Some(entry) = build_entry_from_raw(&bytes, &step.app) {
                             debug!(
                                 "Optimistic state update: {} -> {:?} = {:?}",
-                                control_config.app, entry.addr, entry.value
+                                step.app, entry.addr, entry.value
                             );
                             self.state_actor.update_state(app, entry);
                         }
@@ -335,7 +357,7 @@ impl super::Router {
             } else {
                 warn!(
                     "Bridge driver '{}' not found for MIDI passthrough",
-                    control_config.app
+                    step.app
                 );
             }
         }
@@ -346,11 +368,11 @@ impl super::Router {
         &self,
         raw: &[u8],
         control_id: &str,
-        control_config: &crate::config::ControlMapping,
+        step: &crate::config::ActionStep,
     ) {
         let driver = {
             let drivers = self.drivers.read().await;
-            drivers.get(&control_config.app).cloned()
+            drivers.get(&step.app).cloned()
         };
 
         let driver = match driver {
@@ -358,17 +380,17 @@ impl super::Router {
             None => {
                 warn!(
                     "Driver '{}' not found for control '{}'",
-                    control_config.app, control_id
+                    step.app, control_id
                 );
                 return;
             },
         };
 
         // Determine the action to execute
-        let action = control_config.action.as_deref().unwrap_or("execute");
+        let action = step.action.as_deref().unwrap_or("execute");
 
         // Build parameters
-        let params = control_config.params.clone().unwrap_or_default();
+        let params = step.params.clone().unwrap_or_default();
 
         // Filter button releases: Note Off (0x8) or Note On velocity 0.
         // The X-Touch may send either form depending on firmware/key; both mean
@@ -432,7 +454,7 @@ impl super::Router {
         // Execute driver action
         debug!(
             "→ Routing: {} → app={} action={} (value={:?})",
-            control_id, control_config.app, action, ctx.value
+            control_id, step.app, action, ctx.value
         );
         if let Err(e) = driver.execute(action, params, ctx).await {
             warn!("Driver execution failed: {}", e);

--- a/src/state/actor_handle.rs
+++ b/src/state/actor_handle.rs
@@ -258,13 +258,17 @@ impl StateActorHandle {
         let _ = rx.await;
     }
 
-    /// Clear all states for a specific application
+    /// Clear all states for a specific application.
     ///
-    /// Fire-and-forget: Does not wait for confirmation.
-    pub fn clear_states_for_app(&self, app: AppKey) {
+    /// Lifecycle command (config reload). Uses `send().await` for
+    /// backpressure instead of `try_send`: under a reload burst a full
+    /// command channel must not silently drop this purge, which would let a
+    /// removed app's state leak straight back in (audit #55 regression guard).
+    pub async fn clear_states_for_app(&self, app: AppKey) {
         let _ = self
             .cmd_tx
-            .try_send(StateCommand::ClearStatesForApp { app });
+            .send(StateCommand::ClearStatesForApp { app })
+            .await;
     }
 
     /// Clear all states for all applications
@@ -274,12 +278,14 @@ impl StateActorHandle {
         let _ = self.cmd_tx.try_send(StateCommand::ClearAllStates);
     }
 
-    /// Clear all shadow states (for page refresh)
+    /// Clear all shadow states (for page refresh).
     ///
-    /// Fire-and-forget: Does not wait for confirmation.
-    /// Clears the anti-echo shadow state to allow re-emission during page refresh.
-    pub fn clear_shadows(&self) {
-        let _ = self.cmd_tx.try_send(StateCommand::ClearShadows);
+    /// Uses `send().await` so a full command channel can't drop the clear:
+    /// a dropped clear leaves anti-echo suppressing the refresh's own
+    /// re-emission, which shows up as faders/LEDs not updating on a page
+    /// change. Page refresh is not a per-message hot path, so awaiting is fine.
+    pub async fn clear_shadows(&self) {
+        let _ = self.cmd_tx.send(StateCommand::ClearShadows).await;
     }
 
     // =========================================================================

--- a/src/state/persistence_actor.rs
+++ b/src/state/persistence_actor.rs
@@ -50,6 +50,13 @@ use tracing::{debug, error, info, trace, warn};
 /// Default debounce window in milliseconds
 pub const DEFAULT_DEBOUNCE_MS: u64 = 500;
 
+/// Cap on sled's page cache, in bytes. sled's default `cache_capacity` is
+/// 1 GiB — 20x this project's entire RAM budget. Our databases hold a single
+/// small key (the snapshot / camera targets), so a few MiB is more than
+/// enough and the cap is never actually reached; it just removes the
+/// pathological default ceiling. Shared by the persistence and camera DBs.
+pub const SLED_CACHE_CAPACITY_BYTES: u64 = 16 * 1024 * 1024;
+
 /// Key used to store the snapshot in sled
 const SNAPSHOT_KEY: &[u8] = b"state_snapshot";
 
@@ -108,8 +115,11 @@ impl PersistenceActor {
     ///
     /// Returns an error if the sled database cannot be opened.
     pub fn spawn(db_path: &str, debounce_ms: u64) -> Result<PersistenceActorHandle> {
-        // Open sled database
-        let db = sled::open(db_path)
+        // Open sled database with a bounded page cache (see SLED_CACHE_CAPACITY_BYTES).
+        let db = sled::Config::new()
+            .path(db_path)
+            .cache_capacity(SLED_CACHE_CAPACITY_BYTES)
+            .open()
             .with_context(|| format!("Failed to open sled database at: {}", db_path))?;
 
         info!("Persistence actor opened database at: {}", db_path);

--- a/src/xtouch.rs
+++ b/src/xtouch.rs
@@ -160,6 +160,11 @@ impl XTouchDriver {
 
         let pb_squelch = self.pb_squelch.clone(); // Clone for callback
 
+        // Counts input events dropped because the event channel was full.
+        // Previously dropped silently — a lost NoteOn is a lost button press,
+        // so surface it (rate-limited) for diagnosis.
+        let input_drop_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
         let input_conn = midi_in
             .connect(
                 &in_port,
@@ -188,8 +193,21 @@ impl XTouchDriver {
                             raw_data: data.to_vec(),
                         };
 
-                        // Try to send event, but don't block or panic
-                        let _ = event_tx.try_send(event);
+                        // Try to send event, but don't block or panic. A full
+                        // channel means the main loop is stalled; count + warn
+                        // (rate-limited on powers of two) so the loss is
+                        // diagnosable instead of vanishing.
+                        if event_tx.try_send(event).is_err() {
+                            let n = input_drop_count
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                + 1;
+                            if n == 1 || n.is_power_of_two() {
+                                tracing::warn!(
+                                    "X-Touch input event dropped (event buffer full); total dropped={}",
+                                    n
+                                );
+                            }
+                        }
                     } else {
                         debug!("Failed to parse MIDI: {}", format_hex(data));
                     }


### PR DESCRIPTION
Stacks on #74 (base: `audit/v1.9.0`). Two commits.

## 1. `feat(router)`: feedback-driven toggles, multi-action steps, OBS scene target
The in-progress feature work that was in the working tree:
- `ControlMapping.also` (extra `ActionStep` list) + `toggle` (feedback-edge on/off steps); dispatch refactored into `dispatch_step`/`primary_step` so primary effect, multi-action and toggles share one path.
- Router edge-tracks per-control toggle on/off state (`toggle_states`).
- OBS `changeScene`/`setScene` accept an explicit `program`/`preview` target; split-mode wiring + catalog param.
- Config types, example, and tests.

## 2. `fix(audit)`: MIDI liveness + leak hardening
Output of the v1.9.0 MIDI-loss / leak audit. No unbounded RAM leak existed; the real exposure was MIDI liveness.

**Reconnection / liveness**
- midibridge: reconnect OUT on send failure (was a literal `TODO`); IN/OUT silent-disconnect health monitor (3 s port probe); single-flight guards.
- xtouch: rebuild the driver in the main loop on USB hiccup/replug — no more app restart; dropped input events now logged.
- router: fix re-entrant `config.read()` deadlock in `set_active_page` under hot-reload contention.
- `driver.execute` bounded by a 3 s timeout so a wedged OBS WebSocket can't freeze the single event loop.
- gamepad #75: right-stick deadzone (8689) + trigger threshold (30) kill the idle-controller event flood.

**Leaks / memory**
- OBS: clear indicator/status subscriber Vecs on shutdown; analog 60 Hz timer generation guard.
- winaudio: page-watcher shutdown signal + survive broadcast `Lagged`.
- state: clear toggle edge state on reload; cap sled cache at 16 MiB (was 1 GiB default) on both DBs; lifecycle commands use `send().await`; skip snapshot save when the StateActor is dead.

## Deferred (tracked as separate issues)
Orphaned per-port state purge, anti-echo monotonic clock, tray menu rebuild churn, BUG-006 feedback-during-page-flip ordering.

## Status
`cargo check` / `clippy` / `fmt` clean, **235 tests pass**. The hardware reconnect paths (X-Touch + bridge) need a real unplug/replug to validate end-to-end.